### PR TITLE
Fix CORS configuration and clean up old dashboard remnants

### DIFF
--- a/DASHBOARD_TODO.md
+++ b/DASHBOARD_TODO.md
@@ -19,7 +19,7 @@ Dashboard development is organized into **4 phases**, each with specific feature
 - [ ] **Remove legacy Jinja2 dashboard** - Clean up all docs, backend, frontend, tests, and TODOs related to old dashboard
   - Remove `app/templates/dashboard.html`
   - Remove Jinja2 template rendering code from `app/main.py`
-  - Remove `ENABLE_NEW_DASHBOARD` feature flag from config
+  - ~~Remove `ENABLE_NEW_DASHBOARD` feature flag from config~~ (done)
   - Remove `/dashboard-legacy` route
   - Update all documentation references
   - Remove legacy dashboard tests (`tests/test_existing_dashboard.py`)

--- a/app/config.py
+++ b/app/config.py
@@ -128,6 +128,16 @@ class Settings(BaseSettings):
         description="Delete runners with label drift even if currently running a job",
     )
 
+    # CORS Configuration
+    cors_allowed_origins: list[str] = Field(
+        default=[],
+        description=(
+            "Allowed CORS origins. Empty list disables CORS middleware (use for same-origin "
+            "deployments). Accepts a comma-separated string via env var: "
+            "CORS_ALLOWED_ORIGINS=https://app.example.com,https://other.example.com"
+        ),
+    )
+
     # HTTPS Configuration
     https_enabled: bool = Field(
         default=False,
@@ -142,11 +152,13 @@ class Settings(BaseSettings):
         description="Path to SSL private key file (required if https_enabled=true)",
     )
 
-    # Dashboard Features
-    enable_new_dashboard: bool = Field(
-        default=False,
-        description="Enable new React-based dashboard at /app path",
-    )
+    @field_validator("cors_allowed_origins", mode="before")
+    @classmethod
+    def parse_cors_origins(cls, v: object) -> list[str]:
+        """Allow comma-separated string from env var in addition to a list."""
+        if isinstance(v, str):
+            return [o.strip() for o in v.split(",") if o.strip()]
+        return v  # type: ignore[return-value]
 
     @field_validator("github_app_private_key_path")
     @classmethod

--- a/app/main.py
+++ b/app/main.py
@@ -118,17 +118,17 @@ app = FastAPI(
     openapi_url="/openapi.json",
 )
 
-# Add CORS middleware
-# Allow frontend to access API
-cors_origins = ["*"]  # Configure appropriately for production
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=cors_origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+# Add CORS middleware only when cross-origin access is needed.
+# For same-origin deployments (frontend and API behind the same ingress host),
+# leave CORS_ALLOWED_ORIGINS unset — no middleware is added and requests flow normally.
+if settings.cors_allowed_origins:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors_allowed_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
 
 @app.middleware("http")

--- a/helm/gharts/templates/configmap.yaml
+++ b/helm/gharts/templates/configmap.yaml
@@ -30,7 +30,7 @@ data:
   # Logging
   LOG_LEVEL: {{ .Values.config.logLevel | default "INFO" | quote }}
 
-  # Backend API URL for frontend
-  VITE_API_URL: "http://{{ include "gharts.fullname" . }}-backend:{{ .Values.backend.service.port }}"
-
-
+  # CORS configuration
+  {{- if .Values.backend.cors.allowedOrigins }}
+  CORS_ALLOWED_ORIGINS: {{ .Values.backend.cors.allowedOrigins | join "," | quote }}
+  {{- end }}

--- a/helm/gharts/templates/ingress.yaml
+++ b/helm/gharts/templates/ingress.yaml
@@ -37,6 +37,15 @@ spec:
                 port:
                   number: {{ $.Values.frontend.service.port }}
           {{- end }}
+          {{- if $.Values.backend.ingress.enabled }}
+          - path: {{ $.Values.backend.ingress.path }}
+            pathType: {{ $.Values.backend.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "gharts.fullname" $ }}-backend
+                port:
+                  number: {{ $.Values.backend.service.port }}
+          {{- end }}
     {{- end }}
 {{- end }}
 

--- a/helm/gharts/templates/nginx-configmap.yaml
+++ b/helm/gharts/templates/nginx-configmap.yaml
@@ -68,7 +68,8 @@ data:
                 add_header Content-Type text/plain;
             }
 
-            # API proxy to backend
+            {{- if .Values.frontend.nginx.apiProxy.enabled }}
+            # API proxy to backend (disabled when backend.ingress.enabled=true)
             location /api/ {
                 proxy_pass http://backend;
                 proxy_http_version 1.1;
@@ -81,6 +82,7 @@ data:
                 proxy_cache_bypass $http_upgrade;
                 proxy_read_timeout 90;
             }
+            {{- end }}
 
             # Serve /app/ path - Vite builds with base: '/app/'
             # Rewrite /app/xxx to /xxx and serve from root

--- a/helm/gharts/values.yaml
+++ b/helm/gharts/values.yaml
@@ -85,6 +85,21 @@ backend:
   # Affinity rules
   affinity: {}
 
+  # CORS configuration
+  cors:
+    # Allowed origins for CORS. Empty list disables CORS middleware (same-origin deployment).
+    # Set when the frontend and backend are served from different hosts.
+    # Example: ["https://dashboard.example.com"]
+    allowedOrigins: []
+
+  # Direct ingress routing for the backend API.
+  # When enabled, /api/ is routed directly from the ingress to the backend service,
+  # bypassing the Nginx proxy. Set frontend.nginx.apiProxy.enabled=false in tandem.
+  ingress:
+    enabled: false
+    path: /api/
+    pathType: Prefix
+
 # Frontend (Nginx + React) configuration
 frontend:
   image:
@@ -175,9 +190,17 @@ frontend:
       # Example: "https://{{ .Values.ingress.hosts[0].host }}/app"
       postLogoutRedirectUri: ""
     api:
-      # API base URL (empty string means same-origin)
-      # Set this if frontend and backend are on different domains
+      # API base URL seen by the browser. Empty string means same-origin (recommended default).
+      # Set to a full URL only when the backend is on a different host from the frontend.
+      # Example: "https://api.example.com"
       baseUrl: ""
+
+  # Nginx configuration
+  nginx:
+    apiProxy:
+      # Proxy /api/ requests to the backend from within Nginx.
+      # Set to false when backend.ingress.enabled=true (backend has its own ingress route).
+      enabled: true
 
 # PostgreSQL database configuration (Bitnami subchart)
 # Set enabled=false to use an external managed database (recommended for production)


### PR DESCRIPTION
## Summary

- **Fix broken CORS config**: replaced the invalid `allow_origins=["*"]` + `allow_credentials=True` combination (a CORS spec violation browsers reject) with a configurable, opt-in middleware — no middleware is added when origins are empty, which is correct for same-origin deployments
- **Make CORS configurable**: new `cors_allowed_origins` setting in `app/config.py` (env var `CORS_ALLOWED_ORIGINS`, comma-separated); propagated to the backend via a new Helm value `backend.cors.allowedOrigins`
- **Support direct backend ingress routing**: new `backend.ingress.enabled` Helm value adds a `/api/` path rule pointing straight to the backend service, and `frontend.nginx.apiProxy.enabled` conditionalises the corresponding Nginx proxy block
- **Remove old dashboard remnants**: `enable_new_dashboard` config flag and stray `VITE_API_URL` Helm configmap entry left over from the removed Jinja2 dashboard

## Deployment scenarios

| Scenario | `backend.cors.allowedOrigins` | `frontend.config.api.baseUrl` | `backend.ingress.enabled` |
|---|---|---|---|
| Same host, nginx proxy (default) | `[]` | `""` | `false` |
| Same host, direct backend ingress | `[]` | `""` | `true` + set `frontend.nginx.apiProxy.enabled=false` |
| Different hosts | `["https://app.example.com"]` | `"https://api.example.com"` | either |

## Test plan

- [ ] `helm template` renders `CORS_ALLOWED_ORIGINS` only when `backend.cors.allowedOrigins` is non-empty
- [ ] `helm template` with `backend.ingress.enabled=true` adds a `/api/` path entry pointing to the backend service
- [ ] `helm template` with `frontend.nginx.apiProxy.enabled=false` omits the nginx `/api/` proxy block
- [ ] Backend starts without CORS middleware when `CORS_ALLOWED_ORIGINS` is unset
- [ ] Backend adds CORS middleware with correct origins when `CORS_ALLOWED_ORIGINS` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)