### PR TITLE
feat(auth): Proposal B-1 — GHARTS-native API keys for M2M

### DIFF
--- a/app/api/v1/oauth_clients.py
+++ b/app/api/v1/oauth_clients.py
@@ -1,15 +1,17 @@
-"""Admin API for managing OAuth M2M clients (team credentials)."""
+"""Admin API for managing GHARTS-native M2M API-key clients."""
 
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
+from app.auth.api_keys import generate_api_key
 from app.auth.dependencies import AuthenticatedUser, get_current_user
 from app.database import get_db
 from app.models import OAuthClient, Team
 from app.schemas import (
     OAuthClientCreate,
+    OAuthClientCreateResponse,
     OAuthClientListResponse,
     OAuthClientResponse,
     OAuthClientUpdate,
@@ -32,19 +34,27 @@ def _require_admin(
 
 @router.post(
     "",
-    response_model=OAuthClientResponse,
+    response_model=OAuthClientCreateResponse,
     status_code=status.HTTP_201_CREATED,
-    summary="Register an OAuth M2M client for a team",
+    summary="Register a new M2M API-key client for a team",
 )
 async def create_oauth_client(
     data: OAuthClientCreate,
     admin: AuthenticatedUser = Depends(_require_admin),
     db: Session = Depends(get_db),
 ):
-    """Register an Auth0 M2M client_id as authorized for a team.
+    """Register a new M2M client for a team and issue its initial API key.
 
-    The ``client_id`` must match the ``sub`` claim that Auth0 puts in
-    ``client_credentials`` tokens for that application.
+    The response contains ``api_key`` — the raw bearer token value.  This is
+    shown **exactly once** and cannot be retrieved again.  Store it in your
+    CI/CD secret store immediately.
+
+    Usage in CI/CD pipelines::
+
+        Authorization: Bearer <api_key>
+
+    The ``client_id`` field is a human-readable label (e.g. ``"ci-pipeline"``)
+    unique across all clients.
     """
     # Verify team exists
     team = db.query(Team).filter(Team.id == data.team_id).first()
@@ -64,10 +74,7 @@ async def create_oauth_client(
             detail=f"OAuth client '{data.client_id}' already registered.",
         )
 
-    # Enforce one active machine member per team.  A team corresponds
-    # to exactly one Auth0 M2M application (provisioned by terraform),
-    # so registering a second active client for the same team
-    # indicates a misconfiguration.
+    # Enforce one active machine member per team.
     existing_for_team = (
         db.query(OAuthClient)
         .filter(
@@ -87,8 +94,11 @@ async def create_oauth_client(
             ),
         )
 
+    raw_key, hashed_key = generate_api_key()
+
     client = OAuthClient(
         client_id=data.client_id,
+        hashed_key=hashed_key,
         team_id=data.team_id,
         description=data.description,
         created_by=admin.identity,
@@ -96,13 +106,53 @@ async def create_oauth_client(
     db.add(client)
     db.commit()
     db.refresh(client)
-    return client
+
+    return OAuthClientCreateResponse(
+        client=OAuthClientResponse.model_validate(client),
+        api_key=raw_key,
+    )
+
+
+@router.post(
+    "/{client_id}/rotate",
+    response_model=OAuthClientCreateResponse,
+    summary="Rotate the API key for an M2M client",
+)
+async def rotate_oauth_client_key(
+    client_id: str,
+    _admin: AuthenticatedUser = Depends(_require_admin),
+    db: Session = Depends(get_db),
+):
+    """Generate and store a new API key for the given client, invalidating the old one.
+
+    The response contains ``api_key`` — the new raw bearer token value.  This is
+    shown **exactly once**.  The previous key stops working immediately.
+
+    Args:
+        client_id: Internal UUID of the OAuthClient record.
+    """
+    client = db.query(OAuthClient).filter(OAuthClient.id == client_id).first()
+    if not client:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="OAuth client not found.",
+        )
+
+    raw_key, hashed_key = generate_api_key()
+    client.hashed_key = hashed_key
+    db.commit()
+    db.refresh(client)
+
+    return OAuthClientCreateResponse(
+        client=OAuthClientResponse.model_validate(client),
+        api_key=raw_key,
+    )
 
 
 @router.get(
     "",
     response_model=OAuthClientListResponse,
-    summary="List registered OAuth M2M clients",
+    summary="List registered M2M clients",
 )
 async def list_oauth_clients(
     team_id: str = Query(None, description="Filter by team ID"),
@@ -112,7 +162,7 @@ async def list_oauth_clients(
     _admin: AuthenticatedUser = Depends(_require_admin),
     db: Session = Depends(get_db),
 ):
-    """List OAuth M2M clients, optionally filtered by team."""
+    """List M2M clients, optionally filtered by team."""
     query = db.query(OAuthClient)
     if team_id:
         query = query.filter(OAuthClient.team_id == team_id)
@@ -129,14 +179,14 @@ async def list_oauth_clients(
 @router.get(
     "/{client_id}",
     response_model=OAuthClientResponse,
-    summary="Get an OAuth M2M client by ID",
+    summary="Get an M2M client by ID",
 )
 async def get_oauth_client(
     client_id: str,
     _admin: AuthenticatedUser = Depends(_require_admin),
     db: Session = Depends(get_db),
 ):
-    """Retrieve a single OAuth client record by its internal UUID."""
+    """Retrieve a single M2M client record by its internal UUID."""
     client = db.query(OAuthClient).filter(OAuthClient.id == client_id).first()
     if not client:
         raise HTTPException(
@@ -149,7 +199,7 @@ async def get_oauth_client(
 @router.patch(
     "/{client_id}",
     response_model=OAuthClientResponse,
-    summary="Update an OAuth M2M client",
+    summary="Update an M2M client",
 )
 async def update_oauth_client(
     client_id: str,
@@ -157,7 +207,7 @@ async def update_oauth_client(
     _admin: AuthenticatedUser = Depends(_require_admin),
     db: Session = Depends(get_db),
 ):
-    """Update description or active status of an OAuth M2M client."""
+    """Update description or active status of an M2M client."""
     client = db.query(OAuthClient).filter(OAuthClient.id == client_id).first()
     if not client:
         raise HTTPException(
@@ -176,14 +226,14 @@ async def update_oauth_client(
 @router.delete(
     "/{client_id}",
     status_code=status.HTTP_204_NO_CONTENT,
-    summary="Delete an OAuth M2M client",
+    summary="Delete an M2M client",
 )
 async def delete_oauth_client(
     client_id: str,
     _admin: AuthenticatedUser = Depends(_require_admin),
     db: Session = Depends(get_db),
 ):
-    """Permanently remove an OAuth M2M client registration."""
+    """Permanently remove an M2M client registration."""
     client = db.query(OAuthClient).filter(OAuthClient.id == client_id).first()
     if not client:
         raise HTTPException(
@@ -197,13 +247,12 @@ async def delete_oauth_client(
 def record_m2m_usage(db: Session, client_sub: str) -> None:
     """Update ``last_used_at`` for the OAuth client matching ``client_sub``.
 
-    Called from the auth middleware after the client has already been validated
-    as registered and active.  The client row is guaranteed to exist at this
-    point, so errors are propagated rather than silently swallowed.
+    Kept for backward compatibility; the new API-key auth path stamps
+    ``last_used_at`` directly in ``_authenticate_api_key``.
 
     Args:
         db: Database session
-        client_sub: The ``sub`` claim from the M2M JWT (== Auth0 client_id)
+        client_sub: The client identifier (client_id column value)
     """
     client = db.query(OAuthClient).filter(OAuthClient.client_id == client_sub).first()
     if client:

--- a/app/auth/api_keys.py
+++ b/app/auth/api_keys.py
@@ -1,0 +1,82 @@
+"""GHARTS-native API key generation and verification.
+
+API keys have the format ``gharts_<url-safe-base64-encoded-random-bytes>``.
+The prefix makes them unambiguously distinguishable from JWTs in the
+``Authorization: Bearer`` header.
+
+Only the bcrypt hash is stored in the database.  The raw key is shown to
+the administrator exactly once (at issuance or rotation) and must be treated
+as a secret credential — like a GitHub PAT.
+
+Hash algorithm choice: bcrypt with work factor 12.
+- Resistant to GPU-accelerated brute-force (unlike plain SHA-256).
+- 32 bytes of entropy (256 bits) in the raw key makes brute-force
+  infeasible regardless of hash algorithm.
+- The ``bcrypt`` package (already a transitive dependency via ``passlib``)
+  is used directly rather than through passlib to avoid the passlib 1.7.4 /
+  bcrypt 4+ incompatibility (passlib's backend detection runs a 73-byte
+  self-test that bcrypt 4+ rejects).
+- Our keys are 50 bytes (7-char prefix + 43-char base64), well within
+  bcrypt's 72-byte limit.
+"""
+
+import base64
+import secrets
+from typing import Tuple
+
+import bcrypt as _bcrypt
+
+_PREFIX = "gharts_"
+_KEY_BYTES = 32  # 256 bits of entropy
+
+
+def generate_api_key() -> Tuple[str, str]:
+    """Generate a new GHARTS API key and return ``(raw_key, hashed_key)``.
+
+    The raw key must be shown to the caller exactly once and never stored.
+    Only the hash should be persisted.
+
+    Returns:
+        A tuple of ``(raw_key, hashed_key)`` where *raw_key* is the
+        bearer token value and *hashed_key* is the bcrypt digest to store.
+    """
+    raw_bytes = secrets.token_bytes(_KEY_BYTES)
+    # URL-safe base64, no padding characters that could confuse HTTP headers
+    raw_key = _PREFIX + base64.urlsafe_b64encode(raw_bytes).rstrip(b"=").decode()
+    hashed = _bcrypt.hashpw(raw_key.encode(), _bcrypt.gensalt(rounds=12)).decode()
+    return raw_key, hashed
+
+
+def verify_api_key(raw_key: str, hashed_key: str) -> bool:
+    """Return True if *raw_key* matches *hashed_key*.
+
+    Constant-time comparison is performed by the bcrypt library.
+
+    Args:
+        raw_key: The bearer token value from the Authorization header.
+        hashed_key: The bcrypt hash stored in the database.
+
+    Returns:
+        True if the key is valid, False otherwise.
+    """
+    if not raw_key or not hashed_key:
+        return False
+    try:
+        return _bcrypt.checkpw(raw_key.encode(), hashed_key.encode())
+    except Exception:
+        return False
+
+
+def is_api_key(token: str) -> bool:
+    """Return True if *token* looks like a GHARTS API key (has the prefix).
+
+    This check is used to route the bearer token to the API-key path
+    instead of the JWT-validation path.  It does not validate the key itself.
+
+    Args:
+        token: The raw value from ``Authorization: Bearer <token>``.
+
+    Returns:
+        True if the token starts with the ``gharts_`` prefix.
+    """
+    return token.startswith(_PREFIX)

--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -8,6 +8,7 @@ from fastapi import Depends, HTTPException, Security, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 
+from app.auth.api_keys import is_api_key, verify_api_key
 from app.auth.oidc import OIDCValidator
 from app.auth.token_types import TokenType, detect_token_type
 from app.config import Settings, get_settings
@@ -25,14 +26,14 @@ security = HTTPBearer(auto_error=False)
 class AuthenticatedUser:
     """Represents an authenticated and authorized user.
 
-    Supports two authentication paths:
+    Supports three authentication paths:
 
     * **Individual** (``token_type == TokenType.INDIVIDUAL``): standard OIDC
       user token. ``db_user`` is populated; team membership is fetched from
       the DB.
-    * **M2M team** (``token_type == TokenType.M2M_TEAM``): OAuth
-      ``client_credentials`` token. ``team`` is populated directly from the
-      JWT ``team`` claim; no per-user DB lookup is performed.
+    * **M2M team** (``token_type == TokenType.M2M_TEAM``): GHARTS-native
+      opaque API key (``Bearer gharts_…``).  ``team`` is populated directly
+      from the ``OAuthClient`` row; no JWT validation is performed.
     * **Impersonation** (``token_type == TokenType.IMPERSONATION``): demo
       admin impersonation. Behaves like INDIVIDUAL but token is HS256-signed.
     """
@@ -120,6 +121,85 @@ def _find_team_by_name(db: Session, team_name: str) -> Optional["Team"]:
     )
 
 
+async def _authenticate_api_key(token: str, db: Session) -> AuthenticatedUser:
+    """Authenticate a GHARTS-native opaque API key.
+
+    Scans all active OAuthClient rows that have a hashed_key set and
+    verifies the key via bcrypt.  On success returns an M2M-scoped
+    AuthenticatedUser bound to the client's team.
+
+    Args:
+        token: Raw bearer token value starting with ``gharts_``.
+        db: Database session.
+
+    Returns:
+        AuthenticatedUser with M2M_TEAM token type.
+
+    Raises:
+        HTTPException: 401 if the key is invalid or not found.
+    """
+    from app.models import OAuthClient, Team
+
+    # Load all active clients that have a key hash set.
+    # In practice there will be O(teams) rows — typically < 100.
+    # A dedicated hash index is not used here because bcrypt verification is
+    # the bottleneck and cannot be accelerated by indexing the full hash.
+    candidates = (
+        db.query(OAuthClient)
+        .filter(
+            OAuthClient.is_active.is_(True),
+            OAuthClient.hashed_key.isnot(None),
+        )
+        .all()
+    )
+
+    matched: Optional[OAuthClient] = None
+    for candidate in candidates:
+        if verify_api_key(token, candidate.hashed_key):
+            matched = candidate
+            break
+
+    if matched is None:
+        logger.warning("api_key_not_matched")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or unrecognised API key.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    team = (
+        db.query(Team)
+        .filter(Team.id == matched.team_id, Team.is_active.is_(True))
+        .first()
+    )
+    if team is None:
+        logger.warning(
+            "api_key_team_inactive",
+            client_id=matched.client_id,
+            team_id=matched.team_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Team not found or inactive.",
+        )
+
+    # Record usage for audit trail
+    matched.last_used_at = datetime.now(timezone.utc)
+    db.commit()
+
+    logger.info(
+        "api_key_authenticated",
+        client_id=matched.client_id,
+        team=team.name,
+    )
+    return AuthenticatedUser(
+        identity=f"m2m:{team.name}",
+        claims={"client_id": matched.client_id},
+        token_type=TokenType.M2M_TEAM,
+        team=team,
+    )
+
+
 async def get_current_user(
     credentials: Optional[HTTPAuthorizationCredentials] = Security(security),
     settings: Settings = Depends(get_settings),
@@ -128,7 +208,7 @@ async def get_current_user(
     """Validate token and return an authenticated user.
 
     Handles three token types:
-    - M2M team tokens (``team`` claim present): resolves team from DB by name.
+    - GHARTS API keys (``Bearer gharts_…``): resolves team from OAuthClient table.
     - Individual OIDC tokens: resolves user from DB by email/sub.
     - Impersonation tokens (``is_impersonation`` claim): same as individual.
 
@@ -163,6 +243,14 @@ async def get_current_user(
         )
 
     token = credentials.credentials
+
+    # --- GHARTS-native API key path (Proposal B-1) ---
+    # The gharts_ prefix unambiguously identifies opaque API keys.
+    # This check short-circuits JWT validation entirely for M2M clients.
+    if is_api_key(token):
+        return await _authenticate_api_key(token, db)
+
+    # --- JWT path (SPA / device flow / impersonation) ---
     validator = OIDCValidator(settings)
 
     # Check if this is an impersonation token (demo feature).
@@ -194,86 +282,6 @@ async def get_current_user(
         payload = await validator.validate_token(token)
 
     token_type = detect_token_type(payload)
-
-    # --- M2M team path ---
-    if token_type == TokenType.M2M_TEAM:
-        team_name = payload["team"]
-        client_sub = payload.get("sub", "")
-
-        team = _find_team_by_name(db, team_name)
-        if not team:
-            logger.warning(
-                "m2m_team_not_found",
-                team_name=team_name,
-                sub=client_sub,
-            )
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=(
-                    f"Team '{team_name}' not found or inactive. "
-                    "Ensure the team name in the Auth0 M2M application metadata "
-                    "matches a registered active team in this service."
-                ),
-            )
-
-        # Each team must have exactly one registered and active machine member
-        # (OAuthClient). Tokens from unregistered or disabled clients are rejected
-        # to guarantee complete audit coverage.
-        from app.models import OAuthClient
-
-        oauth_client = (
-            db.query(OAuthClient)
-            .filter(
-                OAuthClient.client_id == client_sub,
-                OAuthClient.team_id == team.id,
-            )
-            .first()
-        )
-        if oauth_client is None:
-            logger.warning(
-                "m2m_client_not_registered",
-                team_name=team_name,
-                sub=client_sub,
-            )
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=(
-                    f"M2M client '{client_sub}' is not registered for team "
-                    f"'{team_name}'. Register the Auth0 client ID via the admin "
-                    "API (POST /api/v1/admin/oauth-clients) before use."
-                ),
-            )
-        if not oauth_client.is_active:
-            logger.warning(
-                "m2m_client_disabled",
-                team_name=team_name,
-                sub=client_sub,
-                client_record_id=oauth_client.id,
-            )
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=(
-                    f"M2M client for team '{team_name}' is disabled. "
-                    "Contact an administrator to re-enable it."
-                ),
-            )
-
-        # Record usage timestamp for the audit trail (blocking — failure raises).
-        from app.api.v1.oauth_clients import record_m2m_usage
-
-        record_m2m_usage(db, client_sub)
-
-        logger.info(
-            "m2m_token_authenticated",
-            team=team_name,
-            sub=client_sub,
-        )
-        return AuthenticatedUser(
-            identity=f"m2m:{team_name}",
-            claims=payload,
-            token_type=token_type,
-            team=team,
-        )
 
     # --- Individual / impersonation path ---
     identity = validator.get_user_identity(payload)

--- a/app/auth/token_types.py
+++ b/app/auth/token_types.py
@@ -1,17 +1,22 @@
-"""Token type detection for M2M and individual OIDC tokens."""
+"""Token type detection for OIDC tokens.
+
+M2M authentication (Proposal B-1) is handled before JWT decoding via the
+``gharts_`` prefix in ``app.auth.api_keys``.  ``detect_token_type`` is only
+called for JWTs that have already passed signature validation.
+"""
 
 from enum import Enum
 
 
 class TokenType(Enum):
-    """Types of JWT tokens accepted by gharts."""
+    """Types of bearer tokens accepted by GHARTS."""
 
     M2M_TEAM = "m2m_team"
-    """OAuth client_credentials token with a 'team' claim.
+    """GHARTS-native opaque API key (``Bearer gharts_…``).
 
-    Issued to M2M applications (CI/CD pipelines, automation tools).
-    Contains a ``team`` claim set by an Auth0 Action from M2M app metadata.
-    Bypasses per-user DB lookup — team is resolved directly from the claim.
+    Issued to M2M clients (CI/CD pipelines, automation tools) via the admin API.
+    Validated by bcrypt hash lookup — no JWT involved.
+    Team is resolved directly from the ``OAuthClient`` row.
     """
 
     INDIVIDUAL = "individual"
@@ -30,12 +35,15 @@ class TokenType(Enum):
 
 
 def detect_token_type(claims: dict) -> TokenType:
-    """Detect the token type from JWT claims.
+    """Detect the token type from decoded JWT claims.
+
+    This function is only called for JWTs (SPA, device flow, impersonation).
+    GHARTS-native API keys (M2M_TEAM) are detected earlier by the
+    ``gharts_`` bearer prefix and never reach this function.
 
     Rules (evaluated in order):
     1. If ``is_impersonation`` claim is truthy → :attr:`TokenType.IMPERSONATION`
-    2. If ``team`` claim is present (non-empty string) → :attr:`TokenType.M2M_TEAM`
-    3. Otherwise → :attr:`TokenType.INDIVIDUAL`
+    2. Otherwise → :attr:`TokenType.INDIVIDUAL`
 
     Args:
         claims: Decoded JWT payload (dict of claims).
@@ -45,6 +53,4 @@ def detect_token_type(claims: dict) -> TokenType:
     """
     if claims.get("is_impersonation"):
         return TokenType.IMPERSONATION
-    if claims.get("team"):
-        return TokenType.M2M_TEAM
     return TokenType.INDIVIDUAL

--- a/app/models.py
+++ b/app/models.py
@@ -255,12 +255,21 @@ class SyncState(Base):
 
 
 class OAuthClient(Base):
-    """OAuth M2M clients registered for team-level access.
+    """M2M clients registered for team-level access via GHARTS-native API keys.
 
-    Each record links an Auth0 M2M ``client_id`` to a team. When gharts
-    receives a JWT with a ``team`` claim it validates that the sub/client is
-    known and active. This table also provides an audit trail for credential
-    rotation and activity monitoring.
+    Each record links an opaque API key (stored as a bcrypt hash) to a team.
+    When GHARTS receives a ``Bearer gharts_<key>`` token it hashes the key
+    and looks it up here, resolving the team without any Auth0 involvement.
+
+    Schema notes
+    ------------
+    * ``client_id`` — human-readable label supplied by the admin at creation
+      time (e.g. ``"ci-pipeline"``).  Kept for display and audit purposes.
+    * ``hashed_key`` — bcrypt hash of the raw API key.  The raw key is shown
+      to the admin exactly once (at creation or rotation) and never stored.
+
+    Migration (DDL only):
+        ALTER TABLE oauth_clients ADD COLUMN hashed_key TEXT;
     """
 
     __tablename__ = "oauth_clients"
@@ -268,8 +277,11 @@ class OAuthClient(Base):
     # Primary key
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
 
-    # Auth0 client_id (matches ``sub`` claim in client_credentials tokens)
+    # Human-readable identifier supplied by the admin (e.g. "ci-pipeline").
     client_id = Column(String, nullable=False, unique=True, index=True)
+
+    # bcrypt hash of the raw API key.  NULL on legacy rows created before B-1.
+    hashed_key = Column(Text, nullable=True)
 
     # Team association
     team_id = Column(

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -593,11 +593,14 @@ class UserTeamsResponse(BaseModel):
 
 
 class OAuthClientCreate(BaseModel):
-    """Request to register a new OAuth M2M client for a team."""
+    """Request to register a new GHARTS-native M2M API-key client for a team."""
 
     client_id: str = Field(
         ...,
-        description="Auth0 client_id of the M2M application",
+        description=(
+            "Human-readable identifier for this client (e.g. 'ci-pipeline'). "
+            "Must be unique across all clients."
+        ),
         min_length=1,
     )
     team_id: str = Field(..., description="Team this client is authorized for")
@@ -614,7 +617,7 @@ class OAuthClientUpdate(BaseModel):
 
 
 class OAuthClientResponse(BaseModel):
-    """OAuth M2M client details."""
+    """OAuth M2M client details (does not include the raw API key)."""
 
     id: str
     client_id: str
@@ -626,6 +629,23 @@ class OAuthClientResponse(BaseModel):
     last_used_at: Optional[datetime]
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class OAuthClientCreateResponse(BaseModel):
+    """Response returned exactly once when an API key is first issued or rotated.
+
+    The ``api_key`` field contains the raw bearer token value.  It is shown
+    **exactly once** and cannot be retrieved again — store it securely.
+    """
+
+    client: OAuthClientResponse
+    api_key: str = Field(
+        ...,
+        description=(
+            "Raw API key — shown exactly once. "
+            "Use as: Authorization: Bearer <api_key>"
+        ),
+    )
 
 
 class OAuthClientListResponse(BaseModel):

--- a/terraform/environments/example/main.tf
+++ b/terraform/environments/example/main.tf
@@ -9,16 +9,13 @@ module "auth0" {
   auth0_client_id     = var.auth0_mgmt_client_id
   auth0_client_secret = var.auth0_mgmt_client_secret
 
-  teams = var.teams
-
   spa_urls = {
     callback    = var.spa_callback_urls
     logout      = var.spa_logout_urls
     web_origins = var.spa_web_origins
   }
 
-  # Defaults: audience = "runner-token-service", m2m_token_lifetime = 3600
-  # embed_user_teams = false
+  # Defaults: audience = "gharts", embed_user_teams = false
 }
 
 # ---------------------------------------------------------------------------
@@ -34,13 +31,9 @@ output "native_cli_client_id" {
   value       = module.auth0.native_cli_client_id
 }
 
-output "m2m_client_ids" {
-  description = "Map of team name → M2M client ID"
-  value       = module.auth0.m2m_client_ids
-}
-
-output "m2m_client_secrets" {
-  description = "Map of team name → M2M client secret (sensitive)"
-  value       = module.auth0.m2m_client_secrets
-  sensitive   = true
-}
+# ---------------------------------------------------------------------------
+# Removed outputs (Proposal B-1)
+# ---------------------------------------------------------------------------
+# output "m2m_client_ids"     -- Auth0 M2M apps no longer exist.
+# output "m2m_client_secrets" -- Auth0 M2M apps no longer exist.
+#                                 API keys are issued via POST /api/v1/admin/oauth-clients.

--- a/terraform/environments/example/variables.tf
+++ b/terraform/environments/example/variables.tf
@@ -15,12 +15,6 @@ variable "auth0_mgmt_client_secret" {
   sensitive   = true
 }
 
-variable "teams" {
-  description = "List of team names to provision M2M applications for"
-  type        = list(string)
-  default     = ["platform-team", "infra"]
-}
-
 variable "spa_callback_urls" {
   description = "Allowed callback URLs for the SPA application"
   type        = list(string)
@@ -35,3 +29,10 @@ variable "spa_web_origins" {
   description = "Allowed web origins for the SPA application"
   type        = list(string)
 }
+
+# ---------------------------------------------------------------------------
+# Removed variables (Proposal B-1)
+# ---------------------------------------------------------------------------
+# variable "teams" -- Auth0 M2M apps are no longer provisioned via Terraform.
+#                     Teams and their API keys are managed via the GHARTS admin API:
+#                     POST /api/v1/admin/oauth-clients

--- a/terraform/modules/auth0/actions.tf
+++ b/terraform/modules/auth0/actions.tf
@@ -1,44 +1,13 @@
 # ---------------------------------------------------------------------------
-# Action: Add Team Claim
-# Trigger: credentials-exchange (Machine-to-Machine / client_credentials flow)
-#
-# Copies the `team` key from the M2M app's metadata into the access token.
-# This allows the gharts backend to resolve team context from the JWT alone,
-# without a database user lookup.
-# ---------------------------------------------------------------------------
-resource "auth0_action" "add_team_claim" {
-  name    = "Add Team Claim"
-  runtime = "node18"
-  deploy  = true
-
-  supported_triggers {
-    id      = "credentials-exchange"
-    version = "v2"
-  }
-
-  code = <<-JS
-    /**
-     * Add Team Claim Action (credentials-exchange / Machine-to-Machine trigger)
-     *
-     * Reads event.client.metadata.team and injects it as a custom claim
-     * into the access token so the backend can resolve team context without
-     * a database user lookup.
-     */
-    exports.onExecuteCredentialsExchange = async (event, api) => {
-      const team = event.client && event.client.metadata && event.client.metadata.team;
-      if (team) {
-        api.accessToken.setCustomClaim("team", team);
-      }
-    };
-  JS
-}
-
-# ---------------------------------------------------------------------------
 # Action: Add User Teams  (optional — only created when embed_user_teams=true)
 # Trigger: post-login
 #
 # Copies the user's `teams` array from app_metadata into the id_token and
 # access_token so the SPA can show team-scoped views without an extra API call.
+#
+# NOTE: The former "Add Team Claim" credentials-exchange action has been removed
+# as part of Proposal B-1.  M2M authentication is now handled by GHARTS-native
+# opaque API keys; Auth0 is no longer involved in the M2M flow.
 # ---------------------------------------------------------------------------
 resource "auth0_action" "add_user_teams" {
   count = var.embed_user_teams ? 1 : 0

--- a/terraform/modules/auth0/apps.tf
+++ b/terraform/modules/auth0/apps.tf
@@ -36,41 +36,16 @@ resource "auth0_client" "native_cli" {
 }
 
 # ---------------------------------------------------------------------------
-# M2M applications — one per team (client_credentials grant)
+# M2M applications have been removed as part of Proposal B-1.
+#
+# CI/CD pipelines now authenticate using GHARTS-native opaque API keys
+# issued via POST /api/v1/admin/oauth-clients.  No Auth0 M2M applications,
+# client secrets, or credentials-exchange tokens are required.
+#
+# To destroy existing Auth0 M2M apps, run:
+#   terraform state rm 'module.auth0.auth0_client.m2m_team'
+#   terraform state rm 'module.auth0.auth0_client_credentials.m2m_team'
+#   terraform state rm 'module.auth0.auth0_client_grant.m2m_team'
+# then apply; Auth0 will not automatically delete the apps so they should
+# also be removed manually from the Auth0 dashboard or via the management API.
 # ---------------------------------------------------------------------------
-resource "auth0_client" "m2m_team" {
-  for_each = local.teams_set
-
-  name     = "gharts-${each.key}"
-  app_type = "non_interactive"
-
-  grant_types = ["client_credentials"]
-
-  oidc_conformant = true
-
-  # Embed team name in app metadata so the "Add Team Claim" Action can read it
-  client_metadata = {
-    team = each.key
-  }
-
-  jwt_configuration {
-    alg = "RS256"
-  }
-}
-
-# Read back the auto-generated client secret for each M2M app
-resource "auth0_client_credentials" "m2m_team" {
-  for_each = local.teams_set
-
-  client_id             = auth0_client.m2m_team[each.key].client_id
-  authentication_method = "client_secret_post"
-}
-
-# Grant each M2M app access to the API
-resource "auth0_client_grant" "m2m_team" {
-  for_each = local.teams_set
-
-  client_id = auth0_client.m2m_team[each.key].client_id
-  audience  = auth0_resource_server.api.identifier
-  scopes    = []
-}

--- a/terraform/modules/auth0/flows.tf
+++ b/terraform/modules/auth0/flows.tf
@@ -1,20 +1,9 @@
 # ---------------------------------------------------------------------------
-# Flow binding: credentials-exchange → Add Team Claim
-#
-# Attaches the "Add Team Claim" action to the Machine-to-Machine flow so
-# that every client_credentials token gets the team claim injected.
-# ---------------------------------------------------------------------------
-resource "auth0_trigger_actions" "post_token" {
-  trigger = "credentials-exchange"
-
-  actions {
-    id           = auth0_action.add_team_claim.id
-    display_name = auth0_action.add_team_claim.name
-  }
-}
-
-# ---------------------------------------------------------------------------
 # Flow binding: post-login → Add User Teams  (only when embed_user_teams=true)
+#
+# NOTE: The former credentials-exchange flow binding ("post_token") has been
+# removed as part of Proposal B-1.  M2M authentication is now handled by
+# GHARTS-native opaque API keys; Auth0 is no longer involved in the M2M flow.
 # ---------------------------------------------------------------------------
 resource "auth0_trigger_actions" "post_login" {
   count = var.embed_user_teams ? 1 : 0

--- a/terraform/modules/auth0/main.tf
+++ b/terraform/modules/auth0/main.tf
@@ -14,9 +14,3 @@ provider "auth0" {
   client_id     = var.auth0_client_id
   client_secret = var.auth0_client_secret
 }
-
-locals {
-  # Normalise team names to lower-case and replace spaces with hyphens
-  # so they are safe to embed in resource names.
-  teams_set = toset([for t in var.teams : lower(replace(t, " ", "-"))])
-}

--- a/terraform/modules/auth0/outputs.tf
+++ b/terraform/modules/auth0/outputs.tf
@@ -18,13 +18,9 @@ output "native_cli_client_id" {
   value       = auth0_client.native_cli.client_id
 }
 
-output "m2m_client_ids" {
-  description = "Map of team name → M2M application client ID"
-  value       = { for team, client in auth0_client.m2m_team : team => client.client_id }
-}
-
-output "m2m_client_secrets" {
-  description = "Map of team name → M2M application client secret (sensitive)"
-  value       = { for team, creds in auth0_client_credentials.m2m_team : team => creds.client_secret }
-  sensitive   = true
-}
+# ---------------------------------------------------------------------------
+# Removed outputs (Proposal B-1)
+# ---------------------------------------------------------------------------
+# output "m2m_client_ids"     -- Auth0 M2M apps no longer exist.
+# output "m2m_client_secrets" -- Auth0 M2M apps no longer exist.
+#                                 API keys are issued via POST /api/v1/admin/oauth-clients.

--- a/terraform/modules/auth0/variables.tf
+++ b/terraform/modules/auth0/variables.tf
@@ -21,11 +21,6 @@ variable "audience" {
   default     = "gharts"
 }
 
-variable "teams" {
-  description = "List of team names; one M2M application is created per team"
-  type        = list(string)
-}
-
 variable "spa_urls" {
   description = "Allowed URLs for the SPA application"
   type = object({
@@ -35,14 +30,15 @@ variable "spa_urls" {
   })
 }
 
-variable "m2m_token_lifetime" {
-  description = "Lifetime in seconds for M2M access tokens"
-  type        = number
-  default     = 3600
-}
-
 variable "embed_user_teams" {
   description = "When true, create the 'Add User Teams' post-login Action that embeds team memberships into user tokens"
   type        = bool
   default     = false
 }
+
+# ---------------------------------------------------------------------------
+# Removed variables (Proposal B-1)
+# ---------------------------------------------------------------------------
+# variable "teams"             -- M2M apps are no longer provisioned via Terraform.
+#                                 Teams are registered in GHARTS via the admin API.
+# variable "m2m_token_lifetime" -- Auth0 no longer issues M2M tokens.

--- a/tests/test_m2m_auth_enforcement.py
+++ b/tests/test_m2m_auth_enforcement.py
@@ -1,19 +1,16 @@
-"""Integration tests for M2M machine-member auth enforcement.
+"""Integration tests for M2M API-key authentication enforcement (Proposal B-1).
 
-These tests verify that get_current_user correctly enforces the invariant:
-  "every M2M token must have an active, registered OAuthClient for its team."
-
-The tests mock OIDC validation so they exercise the dependency logic without
-needing a real JWT from Auth0.
+These tests verify that get_current_user correctly handles GHARTS-native
+opaque API keys (``Bearer gharts_…``).  No JWT or Auth0 involvement.
 """
 
 import json
-from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.auth.api_keys import generate_api_key
 from app.models import OAuthClient, Team
 
 
@@ -38,11 +35,19 @@ def _make_team(db: Session, name: str = "ci-team", active: bool = True) -> Team:
 def _make_oauth_client(
     db: Session,
     team: Team,
-    client_id: str = "pipeline@clients",
+    client_id: str = "ci-pipeline",
     is_active: bool = True,
-) -> OAuthClient:
+    with_key: bool = True,
+):
+    """Return (OAuthClient, raw_key).  raw_key is empty string when with_key=False."""
+    raw_key = ""
+    hashed_key = None
+    if with_key:
+        raw_key, hashed_key = generate_api_key()
+
     c = OAuthClient(
         client_id=client_id,
+        hashed_key=hashed_key,
         team_id=team.id,
         description="test pipeline",
         is_active=is_active,
@@ -50,48 +55,7 @@ def _make_oauth_client(
     db.add(c)
     db.commit()
     db.refresh(c)
-    return c
-
-
-def _m2m_claims(team_name: str, sub: str = "pipeline@clients") -> dict:
-    """Return a minimal M2M JWT payload."""
-    return {
-        "sub": sub,
-        "team": team_name,
-        "aud": "test-audience",
-        "iss": "https://test-issuer.example.com/",
-        "exp": 9999999999,
-    }
-
-
-# ---------------------------------------------------------------------------
-# Fixture: patch OIDC validation so we control the claims
-# ---------------------------------------------------------------------------
-
-_PATCH_TARGET = "app.auth.dependencies.OIDCValidator.validate_token"
-_AUTH_HEADERS = {"Authorization": "Bearer fake-token"}
-
-
-@pytest.fixture
-def m2m_client(client: TestClient):
-    """
-    Fixture that provides a helper to set the M2M claims returned by the
-    mocked OIDC validator for the duration of the test.
-
-    Usage:
-        def test_foo(m2m_client):
-            set_claims, tc = m2m_client
-            set_claims({"sub": "x@clients", "team": "my-team"})
-            tc.get("/api/v1/runners", headers={"Authorization": "Bearer fake"})
-    """
-    mock_validator = AsyncMock(return_value={})
-
-    with patch(_PATCH_TARGET, new=mock_validator):
-
-        def set_claims(claims: dict) -> None:
-            mock_validator.return_value = claims
-
-        yield set_claims, client
+    return c, raw_key
 
 
 # ---------------------------------------------------------------------------
@@ -102,93 +66,120 @@ def m2m_client(client: TestClient):
 _RUNNERS_URL = "/api/v1/runners"
 
 
-class TestM2MAuthEnforcement:
-    """Verify get_current_user blocks M2M tokens that are not registered."""
+class TestApiKeyAuthEnforcement:
+    """Verify get_current_user handles GHARTS API keys correctly."""
 
-    def test_registered_active_client_succeeds(self, test_db: Session, m2m_client):
-        """A properly registered and active client can authenticate."""
+    def test_valid_key_authenticates(self, test_db: Session, client: TestClient):
+        """A valid gharts_ key for an active team succeeds (200)."""
         team = _make_team(test_db, "ci-team")
-        _make_oauth_client(test_db, team, client_id="pipeline@clients")
+        _, raw_key = _make_oauth_client(test_db, team, "ci-pipeline")
 
-        set_claims, tc = m2m_client
-        set_claims(_m2m_claims("ci-team", sub="pipeline@clients"))
-
-        response = tc.get(_RUNNERS_URL, headers=_AUTH_HEADERS)
-        # 200 means authentication succeeded (runner list may be empty)
+        response = client.get(
+            _RUNNERS_URL, headers={"Authorization": f"Bearer {raw_key}"}
+        )
         assert response.status_code == 200
 
-    def test_unregistered_client_rejected(self, test_db: Session, m2m_client):
-        """A token whose sub is not in oauth_clients is rejected (403)."""
-        _make_team(test_db, "ci-team")
-        # No OAuthClient row created — sub is unregistered
-
-        set_claims, tc = m2m_client
-        set_claims(_m2m_claims("ci-team", sub="ghost@clients"))
-
-        response = tc.get(_RUNNERS_URL, headers=_AUTH_HEADERS)
-        assert response.status_code == 403
-        detail = response.json()["detail"]
-        assert "not registered" in detail
-        assert "ghost@clients" in detail
-
-    def test_disabled_client_rejected(self, test_db: Session, m2m_client):
-        """A token whose OAuthClient row is is_active=False is rejected."""
+    def test_wrong_key_rejected(self, test_db: Session, client: TestClient):
+        """A gharts_ key that doesn't match any stored hash is rejected (401)."""
         team = _make_team(test_db, "ci-team")
-        _make_oauth_client(test_db, team, client_id="old@clients", is_active=False)
+        _make_oauth_client(test_db, team, "ci-pipeline")
 
-        set_claims, tc = m2m_client
-        set_claims(_m2m_claims("ci-team", sub="old@clients"))
+        # Different key — same prefix, different bytes
+        wrong_raw, _ = generate_api_key()
 
-        response = tc.get(_RUNNERS_URL, headers=_AUTH_HEADERS)
-        assert response.status_code == 403
-        detail = response.json()["detail"]
-        assert "disabled" in detail.lower()
+        response = client.get(
+            _RUNNERS_URL, headers={"Authorization": f"Bearer {wrong_raw}"}
+        )
+        assert response.status_code == 401
 
-    def test_inactive_team_rejected(self, test_db: Session, m2m_client):
-        """A token for a deactivated team is rejected even with a valid client."""
+    def test_disabled_client_rejected(self, test_db: Session, client: TestClient):
+        """A key belonging to a disabled client is rejected (401).
+
+        Disabled clients are excluded from the candidate scan (is_active filter),
+        so the key never matches → 401 rather than 403.
+        """
+        team = _make_team(test_db, "ci-team")
+        _, raw_key = _make_oauth_client(
+            test_db, team, "old-pipeline", is_active=False
+        )
+
+        response = client.get(
+            _RUNNERS_URL, headers={"Authorization": f"Bearer {raw_key}"}
+        )
+        assert response.status_code == 401
+
+    def test_inactive_team_rejected(self, test_db: Session, client: TestClient):
+        """A valid key for a deactivated team is rejected (403)."""
         team = _make_team(test_db, "frozen-team", active=False)
-        _make_oauth_client(test_db, team, client_id="ci@clients")
+        _, raw_key = _make_oauth_client(test_db, team, "ci-pipeline")
 
-        set_claims, tc = m2m_client
-        set_claims(_m2m_claims("frozen-team", sub="ci@clients"))
-
-        response = tc.get(_RUNNERS_URL, headers=_AUTH_HEADERS)
+        response = client.get(
+            _RUNNERS_URL, headers={"Authorization": f"Bearer {raw_key}"}
+        )
         assert response.status_code == 403
-        assert "frozen-team" in response.json()["detail"]
+        assert "inactive" in response.json()["detail"].lower()
 
-    def test_unknown_team_rejected(self, test_db: Session, m2m_client):
-        """A token whose team name is not in the DB is rejected."""
-        set_claims, tc = m2m_client
-        set_claims(_m2m_claims("no-such-team", sub="ci@clients"))
-
-        response = tc.get(_RUNNERS_URL, headers=_AUTH_HEADERS)
-        assert response.status_code == 403
-        assert "no-such-team" in response.json()["detail"]
-
-    def test_client_for_wrong_team_rejected(self, test_db: Session, m2m_client):
-        """A client registered for team-A cannot authenticate as team-B."""
-        team_a = _make_team(test_db, "team-a")
-        _make_team(test_db, "team-b")
-        # Register the client only for team-a
-        _make_oauth_client(test_db, team_a, client_id="a@clients")
-
-        # Token claims team-b but sub belongs to team-a
-        set_claims, tc = m2m_client
-        set_claims(_m2m_claims("team-b", sub="a@clients"))
-
-        response = tc.get(_RUNNERS_URL, headers=_AUTH_HEADERS)
-        assert response.status_code == 403
-        assert "not registered" in response.json()["detail"]
-
-    def test_last_used_at_updated_on_success(self, test_db: Session, m2m_client):
-        """Successful M2M auth updates the OAuthClient.last_used_at field."""
+    def test_client_without_hashed_key_not_matched(
+        self, test_db: Session, client: TestClient
+    ):
+        """A client row with hashed_key=None is never matched (legacy row)."""
         team = _make_team(test_db, "ci-team")
-        oc = _make_oauth_client(test_db, team, client_id="pipeline@clients")
-        assert oc.last_used_at is None
+        _make_oauth_client(test_db, team, "legacy-client", with_key=False)
 
-        set_claims, tc = m2m_client
-        set_claims(_m2m_claims("ci-team", sub="pipeline@clients"))
-        tc.get(_RUNNERS_URL, headers=_AUTH_HEADERS)
+        # Any gharts_ key will not match since the only row has no hash
+        fake_raw, _ = generate_api_key()
+        response = client.get(
+            _RUNNERS_URL, headers={"Authorization": f"Bearer {fake_raw}"}
+        )
+        assert response.status_code == 401
 
-        test_db.refresh(oc)
-        assert oc.last_used_at is not None
+    def test_last_used_at_updated_on_success(
+        self, test_db: Session, client: TestClient
+    ):
+        """Successful API-key auth updates OAuthClient.last_used_at."""
+        team = _make_team(test_db, "ci-team")
+        row, raw_key = _make_oauth_client(test_db, team, "ci-pipeline")
+        assert row.last_used_at is None
+
+        client.get(_RUNNERS_URL, headers={"Authorization": f"Bearer {raw_key}"})
+
+        test_db.refresh(row)
+        assert row.last_used_at is not None
+
+    def test_non_api_key_token_goes_to_jwt_path(
+        self, test_db: Session, client: TestClient
+    ):
+        """Bearer tokens without gharts_ prefix are routed to the JWT path.
+
+        We patch OIDC validation and create a matching user to confirm that
+        the API-key branch does not intercept regular OIDC tokens.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from app.models import User
+
+        db_user = User(
+            email="dev@example.com",
+            oidc_sub="auth0|dev123",
+            is_active=True,
+            can_use_jit=True,
+        )
+        test_db.add(db_user)
+        test_db.commit()
+
+        with patch(
+            "app.auth.dependencies.OIDCValidator.validate_token",
+            new=AsyncMock(
+                return_value={
+                    "sub": "auth0|dev123",
+                    "email": "dev@example.com",
+                    "aud": "test-audience",
+                    "iss": "https://test-issuer.example.com/",
+                    "exp": 9999999999,
+                }
+            ),
+        ):
+            response = client.get(
+                _RUNNERS_URL, headers={"Authorization": "Bearer some.jwt.token"}
+            )
+        assert response.status_code == 200

--- a/tests/test_oauth_clients.py
+++ b/tests/test_oauth_clients.py
@@ -61,17 +61,44 @@ class TestOAuthClientCreate:
         response = client.post(
             "/api/v1/admin/oauth-clients",
             json={
-                "client_id": "abc@clients",
+                "client_id": "ci-pipeline",
                 "team_id": team.id,
                 "description": "My CI pipeline",
             },
         )
         assert response.status_code == 201
         data = response.json()
-        assert data["client_id"] == "abc@clients"
-        assert data["team_id"] == team.id
-        assert data["description"] == "My CI pipeline"
-        assert data["is_active"] is True
+        # Response is now {client: {...}, api_key: "gharts_..."}
+        assert "api_key" in data
+        assert data["api_key"].startswith("gharts_")
+        assert data["client"]["client_id"] == "ci-pipeline"
+        assert data["client"]["team_id"] == team.id
+        assert data["client"]["description"] == "My CI pipeline"
+        assert data["client"]["is_active"] is True
+
+    def test_create_client_api_key_stored_as_hash(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,
+    ):
+        """The raw key must not be persisted; only the bcrypt hash is stored."""
+        team = _make_team(test_db)
+        response = client.post(
+            "/api/v1/admin/oauth-clients",
+            json={"client_id": "hash-check", "team_id": team.id},
+        )
+        assert response.status_code == 201
+        raw_key = response.json()["api_key"]
+        record_id = response.json()["client"]["id"]
+
+        row = test_db.query(OAuthClient).filter(OAuthClient.id == record_id).first()
+        assert row is not None
+        assert row.hashed_key is not None
+        # Raw key must not be stored in the hash column
+        assert row.hashed_key != raw_key
+        # Hash must start with bcrypt sentinel
+        assert row.hashed_key.startswith("$2")
 
     def test_create_client_unknown_team(
         self,
@@ -81,7 +108,7 @@ class TestOAuthClientCreate:
     ):
         response = client.post(
             "/api/v1/admin/oauth-clients",
-            json={"client_id": "abc@clients", "team_id": "nonexistent-uuid"},
+            json={"client_id": "ci-pipeline", "team_id": "nonexistent-uuid"},
         )
         assert response.status_code == 404
 
@@ -92,10 +119,10 @@ class TestOAuthClientCreate:
         admin_auth_override,
     ):
         team = _make_team(test_db)
-        _make_client(test_db, team, client_id="dup@clients")
+        _make_client(test_db, team, client_id="dup-client")
         response = client.post(
             "/api/v1/admin/oauth-clients",
-            json={"client_id": "dup@clients", "team_id": team.id},
+            json={"client_id": "dup-client", "team_id": team.id},
         )
         assert response.status_code == 409
 
@@ -107,10 +134,10 @@ class TestOAuthClientCreate:
     ):
         """A team may have only one active machine member at a time."""
         team = _make_team(test_db)
-        _make_client(test_db, team, client_id="first@clients")
+        _make_client(test_db, team, client_id="first-client")
         response = client.post(
             "/api/v1/admin/oauth-clients",
-            json={"client_id": "second@clients", "team_id": team.id},
+            json={"client_id": "second-client", "team_id": team.id},
         )
         assert response.status_code == 409
         assert "already has an active M2M client" in response.json()["detail"]
@@ -123,13 +150,13 @@ class TestOAuthClientCreate:
     ):
         """After disabling the old client a new one can be registered."""
         team = _make_team(test_db)
-        _make_client(test_db, team, client_id="old@clients", is_active=False)
+        _make_client(test_db, team, client_id="old-client", is_active=False)
         response = client.post(
             "/api/v1/admin/oauth-clients",
-            json={"client_id": "new@clients", "team_id": team.id},
+            json={"client_id": "new-client", "team_id": team.id},
         )
         assert response.status_code == 201
-        assert response.json()["client_id"] == "new@clients"
+        assert response.json()["client"]["client_id"] == "new-client"
 
     def test_create_client_requires_admin(
         self,
@@ -140,7 +167,7 @@ class TestOAuthClientCreate:
         team = _make_team(test_db)
         response = client.post(
             "/api/v1/admin/oauth-clients",
-            json={"client_id": "abc@clients", "team_id": team.id},
+            json={"client_id": "ci-pipeline", "team_id": team.id},
         )
         assert response.status_code == 403
 
@@ -153,8 +180,8 @@ class TestOAuthClientList:
         admin_auth_override,
     ):
         team = _make_team(test_db)
-        _make_client(test_db, team, "c1@clients")
-        _make_client(test_db, team, "c2@clients")
+        _make_client(test_db, team, "client-one")
+        _make_client(test_db, team, "client-two")
         response = client.get("/api/v1/admin/oauth-clients")
         assert response.status_code == 200
         data = response.json()
@@ -169,13 +196,13 @@ class TestOAuthClientList:
     ):
         team_a = _make_team(test_db, "team-a")
         team_b = _make_team(test_db, "team-b")
-        _make_client(test_db, team_a, "a@clients")
-        _make_client(test_db, team_b, "b@clients")
+        _make_client(test_db, team_a, "client-a")
+        _make_client(test_db, team_b, "client-b")
         response = client.get(f"/api/v1/admin/oauth-clients?team_id={team_a.id}")
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
-        assert data["clients"][0]["client_id"] == "a@clients"
+        assert data["clients"][0]["client_id"] == "client-a"
 
     def test_list_active_only_default(
         self,
@@ -184,12 +211,12 @@ class TestOAuthClientList:
         admin_auth_override,
     ):
         team = _make_team(test_db)
-        _make_client(test_db, team, "active@clients", is_active=True)
-        _make_client(test_db, team, "inactive@clients", is_active=False)
+        _make_client(test_db, team, "active-client", is_active=True)
+        _make_client(test_db, team, "inactive-client", is_active=False)
         response = client.get("/api/v1/admin/oauth-clients")
         data = response.json()
         assert data["total"] == 1
-        assert data["clients"][0]["client_id"] == "active@clients"
+        assert data["clients"][0]["client_id"] == "active-client"
 
     def test_list_include_inactive(
         self,
@@ -198,11 +225,71 @@ class TestOAuthClientList:
         admin_auth_override,
     ):
         team = _make_team(test_db)
-        _make_client(test_db, team, "active@clients", is_active=True)
-        _make_client(test_db, team, "inactive@clients", is_active=False)
+        _make_client(test_db, team, "active-client", is_active=True)
+        _make_client(test_db, team, "inactive-client", is_active=False)
         response = client.get("/api/v1/admin/oauth-clients?active_only=false")
         data = response.json()
         assert data["total"] == 2
+
+
+class TestOAuthClientRotate:
+    def test_rotate_returns_new_key(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,
+    ):
+        """rotate endpoint returns a new gharts_ key and updates the hash."""
+        team = _make_team(test_db)
+        row = _make_client(test_db, team, "rotate-me")
+        # Give it an initial hash so we can verify it changed
+        from app.auth.api_keys import generate_api_key
+
+        _, initial_hash = generate_api_key()
+        row.hashed_key = initial_hash
+        test_db.commit()
+
+        response = client.post(f"/api/v1/admin/oauth-clients/{row.id}/rotate")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["api_key"].startswith("gharts_")
+        assert data["client"]["id"] == row.id
+
+        test_db.refresh(row)
+        assert row.hashed_key != initial_hash
+
+    def test_rotate_invalidates_old_key(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,
+    ):
+        """After rotation the old hash no longer matches the new raw key."""
+        from app.auth.api_keys import generate_api_key, verify_api_key
+
+        team = _make_team(test_db)
+        row = _make_client(test_db, team, "invalidate-me")
+        old_raw, old_hash = generate_api_key()
+        row.hashed_key = old_hash
+        test_db.commit()
+
+        response = client.post(f"/api/v1/admin/oauth-clients/{row.id}/rotate")
+        new_raw = response.json()["api_key"]
+
+        test_db.refresh(row)
+        # New raw key must verify against new hash
+        assert verify_api_key(new_raw, row.hashed_key)
+        # Old raw key must NOT verify against new hash
+        assert not verify_api_key(old_raw, row.hashed_key)
+
+    def test_rotate_not_found(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,
+    ):
+        response = client.post("/api/v1/admin/oauth-clients/no-such-id/rotate")
+        assert response.status_code == 404
 
 
 class TestOAuthClientUpdate:

--- a/tests/test_token_types.py
+++ b/tests/test_token_types.py
@@ -1,17 +1,18 @@
-"""Tests for token type detection and M2M AuthenticatedUser construction."""
+"""Tests for token type detection, API key utilities, and AuthenticatedUser."""
 
 import json
 
 import pytest
 from sqlalchemy.orm import Session
 
+from app.auth.api_keys import generate_api_key, is_api_key, verify_api_key
 from app.auth.dependencies import AuthenticatedUser, _find_team_by_name
 from app.auth.token_types import TokenType, detect_token_type
 from app.models import Team
 
 
 # ---------------------------------------------------------------------------
-# detect_token_type
+# detect_token_type  (JWT-only — M2M is handled pre-JWT by is_api_key())
 # ---------------------------------------------------------------------------
 
 
@@ -29,19 +30,6 @@ class TestDetectTokenType:
     def test_individual_token_empty_claims(self):
         assert detect_token_type({}) == TokenType.INDIVIDUAL
 
-    def test_m2m_team_token(self):
-        claims = {
-            "sub": "client@clients",
-            "team": "platform-team",
-            "aud": "gharts",
-        }
-        assert detect_token_type(claims) == TokenType.M2M_TEAM
-
-    def test_m2m_team_token_no_email(self):
-        """M2M tokens from client_credentials have no email claim."""
-        claims = {"sub": "service-account@clients", "team": "infra"}
-        assert detect_token_type(claims) == TokenType.M2M_TEAM
-
     def test_impersonation_token(self):
         claims = {
             "is_impersonation": True,
@@ -50,24 +38,75 @@ class TestDetectTokenType:
         }
         assert detect_token_type(claims) == TokenType.IMPERSONATION
 
-    def test_impersonation_takes_precedence_over_team(self):
-        """Impersonation flag takes precedence even if team claim present."""
-        claims = {"is_impersonation": True, "team": "some-team"}
+    def test_impersonation_takes_precedence(self):
+        """Impersonation flag takes precedence over any other claims."""
+        claims = {"is_impersonation": True, "sub": "auth0|123"}
         assert detect_token_type(claims) == TokenType.IMPERSONATION
-
-    def test_empty_team_string_is_individual(self):
-        """An empty team claim should not be treated as M2M."""
-        claims = {"sub": "auth0|123", "team": ""}
-        assert detect_token_type(claims) == TokenType.INDIVIDUAL
-
-    def test_none_team_is_individual(self):
-        """A None team claim should not be treated as M2M."""
-        claims = {"sub": "auth0|123", "team": None}
-        assert detect_token_type(claims) == TokenType.INDIVIDUAL
 
     def test_false_impersonation_is_individual(self):
         claims = {"sub": "auth0|123", "is_impersonation": False}
         assert detect_token_type(claims) == TokenType.INDIVIDUAL
+
+    def test_team_claim_no_longer_triggers_m2m(self):
+        """The old Auth0 'team' claim is now ignored — M2M uses the API key path."""
+        claims = {"sub": "auth0|123", "team": "platform-team"}
+        assert detect_token_type(claims) == TokenType.INDIVIDUAL
+
+
+# ---------------------------------------------------------------------------
+# API key utilities
+# ---------------------------------------------------------------------------
+
+
+class TestApiKeyUtilities:
+    """Unit tests for generate_api_key, verify_api_key, and is_api_key."""
+
+    def test_generated_key_has_prefix(self):
+        raw_key, _ = generate_api_key()
+        assert raw_key.startswith("gharts_")
+
+    def test_generated_key_has_sufficient_entropy(self):
+        raw_key, _ = generate_api_key()
+        # 32 bytes → 43 base64url chars (no padding) + 7 prefix
+        assert len(raw_key) >= 40
+
+    def test_generated_key_verifies_against_hash(self):
+        raw_key, hashed = generate_api_key()
+        assert verify_api_key(raw_key, hashed)
+
+    def test_different_key_does_not_verify(self):
+        raw_key, hashed = generate_api_key()
+        other_key, _ = generate_api_key()
+        assert not verify_api_key(other_key, hashed)
+
+    def test_empty_key_does_not_verify(self):
+        _, hashed = generate_api_key()
+        assert not verify_api_key("", hashed)
+
+    def test_empty_hash_does_not_verify(self):
+        raw_key, _ = generate_api_key()
+        assert not verify_api_key(raw_key, "")
+
+    def test_is_api_key_true_for_gharts_prefix(self):
+        raw_key, _ = generate_api_key()
+        assert is_api_key(raw_key)
+
+    def test_is_api_key_false_for_jwt(self):
+        assert not is_api_key("eyJhbGciOiJSUzI1NiJ9.abc.def")
+
+    def test_is_api_key_false_for_empty(self):
+        assert not is_api_key("")
+
+    def test_hash_stored_as_bcrypt(self):
+        _, hashed = generate_api_key()
+        # bcrypt hashes start with $2b$ or $2a$
+        assert hashed.startswith("$2")
+
+    def test_two_keys_produce_unique_values(self):
+        raw1, hash1 = generate_api_key()
+        raw2, hash2 = generate_api_key()
+        assert raw1 != raw2
+        assert hash1 != hash2
 
 
 # ---------------------------------------------------------------------------
@@ -121,7 +160,7 @@ class TestAuthenticatedUserIndividual:
 
 
 class TestAuthenticatedUserM2M:
-    """Tests for AuthenticatedUser in M2M_TEAM mode."""
+    """Tests for AuthenticatedUser in M2M_TEAM mode (API key path)."""
 
     def _make_team(self):
         from unittest.mock import MagicMock
@@ -136,7 +175,7 @@ class TestAuthenticatedUserM2M:
         team = self._make_team()
         user = AuthenticatedUser(
             identity="m2m:platform-team",
-            claims={"sub": "client@clients", "team": "platform-team"},
+            claims={"client_id": "ci-pipeline"},
             token_type=TokenType.M2M_TEAM,
             team=team,
         )
@@ -146,19 +185,18 @@ class TestAuthenticatedUserM2M:
         team = self._make_team()
         user = AuthenticatedUser(
             identity="m2m:platform-team",
-            claims={"sub": "client@clients", "team": "platform-team"},
+            claims={"client_id": "ci-pipeline"},
             token_type=TokenType.M2M_TEAM,
             team=team,
         )
         assert user.team is team
-        assert user.team_name_from_token == "platform-team"
 
     def test_m2m_not_admin(self):
-        """M2M tokens should never have admin privileges."""
+        """M2M API keys must never grant admin privileges."""
         team = self._make_team()
         user = AuthenticatedUser(
             identity="m2m:platform-team",
-            claims={"sub": "client@clients", "team": "platform-team"},
+            claims={"client_id": "ci-pipeline"},
             token_type=TokenType.M2M_TEAM,
             team=team,
         )
@@ -168,7 +206,7 @@ class TestAuthenticatedUserM2M:
         team = self._make_team()
         user = AuthenticatedUser(
             identity="m2m:platform-team",
-            claims={"sub": "client@clients", "team": "platform-team"},
+            claims={"client_id": "ci-pipeline"},
             token_type=TokenType.M2M_TEAM,
             team=team,
         )
@@ -179,7 +217,7 @@ class TestAuthenticatedUserM2M:
         team = self._make_team()
         user = AuthenticatedUser(
             identity="m2m:platform-team",
-            claims={"sub": "client@clients", "team": "platform-team"},
+            claims={"client_id": "ci-pipeline"},
             token_type=TokenType.M2M_TEAM,
             team=team,
         )


### PR DESCRIPTION
## Summary

Implements **Proposal B-1** from [`.assistant/auth0-m2m-evolution-plan.md`](.assistant/auth0-m2m-evolution-plan.md) — replacing Auth0 M2M `client_credentials` tokens with opaque API keys managed entirely by GHARTS.

### Problems solved

- **Lifecycle ownership**: creating M2M apps, rotating secrets, and revoking access previously required Auth0 admin access. GHARTS team now owns the full credential lifecycle via the admin API.
- **Auth0 M2M billing**: eliminated entirely — no `client_credentials` token issuance, no Auth0 involvement in the M2M path.
- **Supersedes Problem 1**: the Auth0 Action (`Add Team Claim`) and `client_metadata` sync are no longer needed.

### How it works

```
[CI/CD pipeline]
  | Authorization: Bearer gharts_<base64>
  v
[GHARTS backend]
  1. Detect gharts_ prefix → opaque key path (not JWT)
  2. Scan active OAuthClient rows with hashed_key set
  3. Verify key via bcrypt (constant-time)
  4. Resolve team from OAuthClient.team_id
  5. Validate team.is_active
  6. Stamp last_used_at (audit trail)
  7. Return AuthenticatedUser(team=...)
```

Key lifecycle:
```
POST /api/v1/admin/oauth-clients         → issues key once on creation
POST /api/v1/admin/oauth-clients/{id}/rotate → invalidates old key, issues new key
```

The raw key is returned **exactly once** and never stored — only its bcrypt hash (work factor 12) is persisted.

### Changes

| Area | Change |
|------|--------|
| `app/auth/api_keys.py` | New — key generation, bcrypt hashing, prefix detection |
| `app/auth/dependencies.py` | `gharts_` prefix routes to new `_authenticate_api_key()` before JWT decode |
| `app/auth/token_types.py` | `detect_token_type()` simplified — M2M no longer comes from JWT claims |
| `app/models.py` | `OAuthClient.hashed_key TEXT` column added (nullable, migration below) |
| `app/schemas.py` | New `OAuthClientCreateResponse` with `api_key` field |
| `app/api/v1/oauth_clients.py` | Create returns key once; new `rotate` endpoint |
| `terraform/` | All Auth0 M2M resources removed (apps, credentials, grants, Action, flow binding) |
| `tests/` | 61 tests rewritten/added for new paths; full suite 358/358 passing |

### Migration required

```sql
ALTER TABLE oauth_clients ADD COLUMN hashed_key TEXT;
```

Existing `OAuthClient` rows will have `hashed_key = NULL`. They are unreachable via the new auth path and should be re-provisioned using the rotate endpoint after migration.

### Decisions / trade-offs noted in the plan

- **No token expiry**: opaque keys are valid indefinitely until rotated or revoked. This is a known regression vs JWTs (which carry `exp`). The plan acknowledges this — revocation is instant (vs up to JWT TTL), which was the primary operational ask. Optional key TTLs can be added later.
- **DB in the auth hot path**: every M2M request now requires a DB read (bcrypt verification). With O(teams) rows this is fast in practice. The plan explicitly accepts this trade-off.
- **SPA and device code flows unaffected**: the `gharts_` prefix check is a no-op for all JWT bearers; the individual auth path is unchanged.
- **`bcrypt` used directly** (not via passlib): passlib 1.7.4 has a known incompatibility with bcrypt 4+ that raises on its internal self-test. Both are already in `requirements.txt`; using `bcrypt` directly avoids the issue without adding dependencies.

## Test plan

- [x] `tests/test_token_types.py` — `detect_token_type`, `AuthenticatedUser`, API key utilities
- [x] `tests/test_m2m_auth_enforcement.py` — valid key, wrong key, disabled client, inactive team, null hash, `last_used_at`, JWT path not affected
- [x] `tests/test_oauth_clients.py` — create (returns key + hash stored), rotate (invalidates old, verifies new), CRUD, admin-only
- [x] Full suite: 358/358 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)