### PR TITLE
fix: add required URL parameter for IAM auth database engine

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -91,6 +91,7 @@ def get_engine_config():
             )
 
         return {
+            "url": "postgresql://",  # Dummy URL for dialect detection; actual connection via creator
             "creator": _iam_creator,
             "echo": False,
             "pool_size": settings.db_pool_size,


### PR DESCRIPTION
## Problem

When `db_iam_auth=true`, the `get_engine_config()` function returns a config dict with a `creator` function but no `url` key. This causes a TypeError when `create_engine(**config)` is called because SQLAlchemy's `create_engine()` requires `url` as the first positional argument.

## Error
```
TypeError: create_engine() missing 1 required positional argument: 'url'
```

## Solution

Added `"url": "postgresql://"` to the IAM auth config dict. This minimal URL:
- Identifies the PostgreSQL dialect for SQLAlchemy
- Allows the engine to be configured properly  
- Doesn't interfere with the creator function which handles actual connections

The actual connection parameters (host, port, database, credentials) come from the creator function which fetches fresh IAM tokens from AWS.

## Testing

This fix resolves the deployment failure in v0.0.4 where the backend pod crashed on startup with the IAM auth error.

Related to failed release: https://github.com/afrittoli/gha-runner-token-service/actions/runs/24477134785

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>