### PR TITLE
fix: make verify-deployment job re-runnable and add frontend build timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,7 @@ jobs:
   build-and-push-frontend:
     runs-on: ubuntu-latest
     needs: create-release
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
@@ -216,6 +217,20 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Get version
+        id: get_version
+        run: |
+          # Try to use version from create-release job output first
+          VERSION="${{ needs.create-release.outputs.version }}"
+          # Fall back to extracting from git tag if not available (e.g., during re-runs)
+          if [ -z "$VERSION" ]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+            echo "Using version from git tag: $VERSION"
+          else
+            echo "Using version from create-release job: $VERSION"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
       - name: Set up kind
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
@@ -228,7 +243,7 @@ jobs:
 
       - name: Deploy to kind
         run: |
-          VERSION=${{ needs.create-release.outputs.version }}
+          VERSION=${{ steps.get_version.outputs.version }}
 
           # Update Chart version
           sed -i "s/^version:.*/version: ${VERSION}/" helm/gharts/Chart.yaml


### PR DESCRIPTION
## Problem

The v0.0.4 release workflow had two issues:

1. **Frontend build timeout**: The `build-and-push-frontend` job hung for 6 hours until hitting GitHub Actions' maximum execution time, likely due to the vite dependency updates.

2. **Verify-deployment not re-runnable**: The `verify-deployment` job depends on `needs.create-release.outputs.version`, which is not available when re-running failed jobs. This prevents completing the release verification without creating a new release.

## Solution

### 1. Add timeout to frontend build
- Added `timeout-minutes: 60` to `build-and-push-frontend` job
- Prevents 6-hour hangs and fails faster if build gets stuck
- 60 minutes allows sufficient time for multi-platform Docker builds

### 2. Make verify-deployment resilient with fallback
- Added smart version detection that prefers `needs.create-release.outputs.version`
- Falls back to extracting from git tag (`GITHUB_REF`) when output is unavailable
- Includes logging to show which source was used
- Allows re-running the job independently after fixing issues

## Benefits

- Faster failure detection for stuck builds (1 hour vs 6 hours)
- Can re-run verification without creating new releases
- Reduces wasted CI time and resources
- Makes the release process more resilient
- Maintains backward compatibility with normal workflow runs

## Testing

The changes maintain backward compatibility:
- Version extraction logic is identical to `create-release` job
- Normal workflow runs use the preferred job output
- Re-runs automatically fall back to git tag
- All existing functionality preserved

Related to failed release: https://github.com/afrittoli/gha-runner-token-service/actions/runs/24477134785

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>