### PR TITLE
refactor: simplify frontend nginx and move routing to ingress/gateway

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -90,19 +90,19 @@ jobs:
           echo "✅ Secrets created"
 
       - name: Deploy helm chart with ingress
+        env:
+          BACKEND_TAG: ${{ github.event.inputs.backend_tag }}
+          FRONTEND_TAG: ${{ github.event.inputs.frontend_tag }}
         run: |
-          BACKEND_TAG="${{ github.event.inputs.backend_tag }}"
-          FRONTEND_TAG="${{ github.event.inputs.frontend_tag }}"
-          
           echo "Deploying with:"
           echo "  Backend: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}:${BACKEND_TAG}"
           echo "  Frontend: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}:${FRONTEND_TAG}"
           
           helm install gharts ./helm/gharts --wait --timeout 10m \
             --set backend.image.repository=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }} \
-            --set backend.image.tag=${BACKEND_TAG} \
+            --set backend.image.tag="${BACKEND_TAG}" \
             --set frontend.image.repository=${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }} \
-            --set frontend.image.tag=${FRONTEND_TAG} \
+            --set frontend.image.tag="${FRONTEND_TAG}" \
             --set postgresql.enabled=true \
             --set postgresql.auth.username=testuser \
             --set postgresql.auth.password=testpass \
@@ -232,13 +232,17 @@ jobs:
 
       - name: Summary
         if: success()
+        env:
+          BACKEND_TAG: ${{ github.event.inputs.backend_tag }}
+          FRONTEND_TAG: ${{ github.event.inputs.frontend_tag }}
+          HELM_CHART_REF: ${{ github.event.inputs.helm_chart_ref }}
         run: |
           echo "✅ Integration test completed successfully!"
           echo ""
           echo "Tested configuration:"
-          echo "  Backend: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}:${{ github.event.inputs.backend_tag }}"
-          echo "  Frontend: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}:${{ github.event.inputs.frontend_tag }}"
-          echo "  Chart ref: ${{ github.event.inputs.helm_chart_ref }}"
+          echo "  Backend: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}:${BACKEND_TAG}"
+          echo "  Frontend: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}:${FRONTEND_TAG}"
+          echo "  Chart ref: ${HELM_CHART_REF}"
           echo ""
           echo "Verified:"
           echo "  ✅ Direct service connectivity"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,248 @@
+name: Integration Test (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend_tag:
+        description: 'Backend image tag to test'
+        required: false
+        default: 'latest'
+      frontend_tag:
+        description: 'Frontend image tag to test'
+        required: false
+        default: 'latest'
+      helm_chart_ref:
+        description: 'Git ref for helm chart (branch/tag/commit)'
+        required: false
+        default: 'main'
+
+permissions: read-all
+
+env:
+  REGISTRY: ghcr.io
+  BACKEND_IMAGE_NAME: ${{ github.repository }}-backend
+  FRONTEND_IMAGE_NAME: ${{ github.repository }}-frontend
+
+jobs:
+  integration-test:
+    name: Integration Test with Ingress
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.helm_chart_ref }}
+
+      - name: Set up kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          cluster_name: integration-test
+          config: |
+            kind: Cluster
+            apiVersion: kind.x-k8s.io/v1alpha4
+            nodes:
+            - role: control-plane
+              kubeadmConfigPatches:
+              - |
+                kind: InitConfiguration
+                nodeRegistration:
+                  kubeletExtraArgs:
+                    node-labels: "ingress-ready=true"
+              extraPortMappings:
+              - containerPort: 80
+                hostPort: 80
+                protocol: TCP
+              - containerPort: 443
+                hostPort: 443
+                protocol: TCP
+
+      - name: Install nginx-ingress controller
+        run: |
+          echo "Installing nginx-ingress controller..."
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+          
+          echo "Waiting for ingress controller to be ready..."
+          kubectl wait --namespace ingress-nginx \
+            --for=condition=ready pod \
+            --selector=app.kubernetes.io/component=controller \
+            --timeout=90s
+          
+          echo "✅ Nginx-ingress controller ready"
+
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: 'v3.13.0'
+
+      - name: Create required secrets
+        run: |
+          echo "Creating GitHub App secret..."
+          kubectl create secret generic gharts-github \
+            --from-literal=private-key.pem="-----BEGIN RSA PRIVATE KEY-----
+          MIIEpAIBAAKCAQEAtest-key-for-integration-testing
+          -----END RSA PRIVATE KEY-----"
+          
+          echo "Creating OIDC secret..."
+          kubectl create secret generic gharts-oidc \
+            --from-literal=oidc-client-id=test-client-id
+          
+          echo "✅ Secrets created"
+
+      - name: Deploy helm chart with ingress
+        run: |
+          BACKEND_TAG="${{ github.event.inputs.backend_tag }}"
+          FRONTEND_TAG="${{ github.event.inputs.frontend_tag }}"
+          
+          echo "Deploying with:"
+          echo "  Backend: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}:${BACKEND_TAG}"
+          echo "  Frontend: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}:${FRONTEND_TAG}"
+          
+          helm install gharts ./helm/gharts --wait --timeout 10m \
+            --set backend.image.repository=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }} \
+            --set backend.image.tag=${BACKEND_TAG} \
+            --set frontend.image.repository=${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }} \
+            --set frontend.image.tag=${FRONTEND_TAG} \
+            --set postgresql.enabled=true \
+            --set postgresql.auth.username=testuser \
+            --set postgresql.auth.password=testpass \
+            --set postgresql.auth.database=testdb \
+            --set github.organization=test-org \
+            --set github.appId=123456 \
+            --set github.installationId=789 \
+            --set github.privateKeySecret=gharts-github \
+            --set github.privateKeySecretKey=private-key.pem \
+            --set oidc.enabled=true \
+            --set oidc.issuer=https://example.com/ \
+            --set oidc.audience=gharts \
+            --set oidc.jwksUrl=https://example.com/.well-known/jwks.json \
+            --set oidc.clientIdSecret=gharts-oidc \
+            --set oidc.clientIdSecretKey=oidc-client-id \
+            --set ingress.enabled=true \
+            --set ingress.className=nginx \
+            --set ingress.hosts[0].host=test.local \
+            --set ingress.hosts[0].paths[0].path=/ \
+            --set ingress.hosts[0].paths[0].pathType=Prefix
+          
+          echo "✅ Helm chart deployed"
+
+      - name: Wait for pods to be ready
+        run: |
+          echo "Waiting for backend pods..."
+          kubectl wait --for=condition=ready pod \
+            -l app.kubernetes.io/name=gharts,app.kubernetes.io/component=backend \
+            --timeout=120s
+          
+          echo "Waiting for frontend pods..."
+          kubectl wait --for=condition=ready pod \
+            -l app.kubernetes.io/name=gharts,app.kubernetes.io/component=frontend \
+            --timeout=120s
+          
+          echo "✅ All pods ready"
+
+      - name: Check deployment status
+        run: |
+          echo "=== Pods ==="
+          kubectl get pods -l app.kubernetes.io/name=gharts
+          
+          echo ""
+          echo "=== Services ==="
+          kubectl get svc -l app.kubernetes.io/name=gharts
+          
+          echo ""
+          echo "=== Ingress ==="
+          kubectl get ingress
+          kubectl describe ingress gharts
+
+      - name: Test direct service connectivity
+        run: |
+          echo "Testing direct backend service connectivity..."
+          kubectl run curl-backend --image=curlimages/curl:latest --rm -i --restart=Never -- \
+            curl -f -v http://gharts-backend:8000/health
+          
+          echo ""
+          echo "Testing direct frontend service connectivity..."
+          kubectl run curl-frontend --image=curlimages/curl:latest --rm -i --restart=Never -- \
+            curl -f -v http://gharts-frontend:80/health
+          
+          echo "✅ Direct service connectivity works"
+
+      - name: Test ingress routing - API to backend
+        run: |
+          echo "Testing /api/health → backend through ingress..."
+          
+          # Get ingress controller pod
+          INGRESS_POD=$(kubectl get pods -n ingress-nginx -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}')
+          
+          # Test from inside the cluster (ingress controller perspective)
+          kubectl exec -n ingress-nginx ${INGRESS_POD} -- \
+            curl -f -v -H "Host: test.local" http://localhost/api/health
+          
+          echo "✅ API routing through ingress works"
+
+      - name: Test ingress routing - Frontend
+        run: |
+          echo "Testing / → frontend through ingress..."
+          
+          # Get ingress controller pod
+          INGRESS_POD=$(kubectl get pods -n ingress-nginx -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}')
+          
+          # Test from inside the cluster (ingress controller perspective)
+          kubectl exec -n ingress-nginx ${INGRESS_POD} -- \
+            curl -f -v -H "Host: test.local" http://localhost/health
+          
+          echo "✅ Frontend routing through ingress works"
+
+      - name: Test ingress routing - SPA routes
+        run: |
+          echo "Testing /runners → frontend (SPA routing) through ingress..."
+          
+          # Get ingress controller pod
+          INGRESS_POD=$(kubectl get pods -n ingress-nginx -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}')
+          
+          # Test SPA route - should return HTML (200) not 404
+          kubectl exec -n ingress-nginx ${INGRESS_POD} -- \
+            curl -f -v -H "Host: test.local" http://localhost/runners
+          
+          echo "✅ SPA routing through ingress works"
+
+      - name: Run helm tests
+        run: |
+          echo "Running helm tests..."
+          helm test gharts --timeout 5m
+          echo "✅ Helm tests passed"
+
+      - name: Check logs on failure
+        if: failure()
+        run: |
+          echo "=== Backend Logs ==="
+          kubectl logs -l app.kubernetes.io/name=gharts,app.kubernetes.io/component=backend --tail=100
+          
+          echo ""
+          echo "=== Frontend Logs ==="
+          kubectl logs -l app.kubernetes.io/name=gharts,app.kubernetes.io/component=frontend --tail=100
+          
+          echo ""
+          echo "=== Ingress Controller Logs ==="
+          kubectl logs -n ingress-nginx -l app.kubernetes.io/component=controller --tail=100
+          
+          echo ""
+          echo "=== Pod Descriptions ==="
+          kubectl describe pods -l app.kubernetes.io/name=gharts
+
+      - name: Summary
+        if: success()
+        run: |
+          echo "✅ Integration test completed successfully!"
+          echo ""
+          echo "Tested configuration:"
+          echo "  Backend: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}:${{ github.event.inputs.backend_tag }}"
+          echo "  Frontend: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}:${{ github.event.inputs.frontend_tag }}"
+          echo "  Chart ref: ${{ github.event.inputs.helm_chart_ref }}"
+          echo ""
+          echo "Verified:"
+          echo "  ✅ Direct service connectivity"
+          echo "  ✅ Ingress routing: /api/* → backend"
+          echo "  ✅ Ingress routing: /* → frontend"
+          echo "  ✅ SPA routing through ingress"
+          echo "  ✅ Helm tests"

--- a/docs/kubernetes_deployment.md
+++ b/docs/kubernetes_deployment.md
@@ -267,6 +267,12 @@ config:
 
 ### Ingress Configuration
 
+The application uses a **split routing architecture** where the ingress/gateway handles routing decisions:
+- `/api/*` routes to the backend service
+- All other paths (`/*`) route to the frontend service
+
+The frontend nginx container serves static files and handles SPA routing, but does **not** proxy API requests. This provides a cleaner separation of concerns and makes the frontend more portable.
+
 #### Using Nginx Ingress
 
 ```yaml
@@ -276,6 +282,8 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # Rewrite rules are automatically configured by the chart
+    # to handle /api/* → backend and /* → frontend
   hosts:
     - host: gharts.example.com
       paths:
@@ -286,6 +294,20 @@ ingress:
       hosts:
         - gharts.example.com
 ```
+
+**How Nginx Ingress Routing Works:**
+
+The chart configures two path rules with regex matching:
+1. `/api(/|$)(.*)` → backend service (matched first, more specific)
+2. `/(.*)` → frontend service (catch-all for SPA routes)
+
+The `nginx.ingress.kubernetes.io/rewrite-target: /$2` annotation captures the path after `/api` or `/` and forwards it to the respective service. This handles trailing slashes automatically.
+
+**Example routing:**
+- `https://gharts.example.com/api/runners` → backend:8000/api/runners
+- `https://gharts.example.com/api/` → backend:8000/api
+- `https://gharts.example.com/` → frontend:80/
+- `https://gharts.example.com/runners/123` → frontend:80/ (nginx serves index.html, React Router handles /runners/123)
 
 #### Using Gateway API
 
@@ -306,6 +328,29 @@ gateway:
         certificateRefs:
           - name: gharts-tls
 ```
+
+**How Gateway API Routing Works:**
+
+The HTTPRoute resource defines two rules evaluated in order:
+1. PathPrefix `/api` → backend service (checked first)
+2. PathPrefix `/` → frontend service (catch-all)
+
+Gateway API uses simple prefix matching (no regex needed). The longest matching prefix wins, so `/api` takes precedence over `/` for API requests.
+
+**Example routing:**
+- `https://gharts.example.com/api/runners` → backend:8000/api/runners
+- `https://gharts.example.com/api/` → backend:8000/api/
+- `https://gharts.example.com/` → frontend:80/
+- `https://gharts.example.com/runners/123` → frontend:80/ (nginx serves index.html, React Router handles /runners/123)
+
+**Key Differences:**
+
+| Aspect | Nginx Ingress | Gateway API |
+|--------|--------------|-------------|
+| Path Matching | Regex with capture groups | Simple PathPrefix |
+| Order | Longer paths matched first | Rules evaluated in order |
+| Trailing Slash | Handled via rewrite-target | Native PathPrefix behavior |
+| Flexibility | Very flexible (regex) | Simpler, more standardized |
 
 ### Autoscaling Configuration
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -56,20 +56,6 @@ http {
             add_header Content-Type text/plain;
         }
 
-        # API proxy to backend
-        location /api/ {
-            proxy_pass http://backend:8000;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection 'upgrade';
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_cache_bypass $http_upgrade;
-            proxy_read_timeout 90;
-        }
-
         # Static assets with caching
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
             expires 1y;

--- a/helm/gharts/templates/httproute.yaml
+++ b/helm/gharts/templates/httproute.yaml
@@ -18,6 +18,15 @@ spec:
     - {{ .hostname | quote }}
   {{- end }}
   rules:
+    # API routes go to backend service (matched first due to more specific path)
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+      backendRefs:
+        - name: {{ include "gharts.fullname" $ }}-backend
+          port: {{ $.Values.backend.service.port }}
+    # All other routes go to frontend service (SPA)
     - matches:
         - path:
             type: PathPrefix

--- a/helm/gharts/templates/ingress.yaml
+++ b/helm/gharts/templates/ingress.yaml
@@ -5,10 +5,13 @@ metadata:
   name: {{ include "gharts.fullname" . }}
   labels:
     {{- include "gharts.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+    # Redirect trailing slashes (e.g., /api/ → /api)
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
@@ -28,15 +31,22 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            pathType: {{ .pathType }}
+          # API routes go to backend service (matched first due to longer prefix)
+          - path: /api(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ include "gharts.fullname" $ }}-backend
+                port:
+                  number: {{ $.Values.backend.service.port }}
+          # All other routes go to frontend service (SPA)
+          - path: /(.*)
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ include "gharts.fullname" $ }}-frontend
                 port:
                   number: {{ $.Values.frontend.service.port }}
-          {{- end }}
     {{- end }}
 {{- end }}
 

--- a/helm/gharts/templates/nginx-configmap.yaml
+++ b/helm/gharts/templates/nginx-configmap.yaml
@@ -68,6 +68,11 @@ data:
                 add_header Content-Type text/plain;
             }
 
+            # API proxy to backend - redirect /api to /api/
+            location = /api {
+                return 301 $scheme://$http_host/api/;
+            }
+
             # API proxy to backend
             location /api/ {
                 proxy_pass http://backend;


### PR DESCRIPTION
- Remove API proxy from frontend nginx.conf - ingress now handles routing
- Update ingress.yaml to route /api/* to backend and /* to frontend
- Update httproute.yaml (Gateway API) with same routing logic
- Add comprehensive documentation on routing architecture
- Frontend nginx now only serves static files and handles SPA routing

Benefits:
- Cleaner architecture (routing at ingress, serving at nginx)
- Frontend container is simpler and more portable
- Works with both Ingress and Gateway API
- Easier to maintain and understand