### PR TITLE
feat: store stable User.id in audit/ownership fields; surface oidc_sub in UI

### DIFF
--- a/app/api/v1/admin.py
+++ b/app/api/v1/admin.py
@@ -12,7 +12,10 @@ from app.config import Settings, get_settings
 from app.database import get_db
 from app.models import (
     AuditLog,
+    Runner,
     SecurityEvent,
+    User,
+    resolve_user_display,
 )
 from app.schemas import (
     BatchActionResponse,
@@ -99,14 +102,31 @@ async def list_security_events(
     - `high`: Security violation detected and mitigated
     - `critical`: Severe security violation
     """
+    # Resolve user_identity filter to a user_id if supplied
+    resolved_user_id: Optional[str] = None
+    if user_identity:
+        resolved_user = (
+            db.query(User)
+            .filter(
+                (User.id == user_identity)
+                | (User.email == user_identity)
+                | (User.oidc_sub == user_identity)
+            )
+            .first()
+        )
+        if resolved_user:
+            resolved_user_id = resolved_user.id
+        else:
+            return SecurityEventListResponse(events=[], total=0)
+
     query = db.query(SecurityEvent)
 
     if event_type:
         query = query.filter(SecurityEvent.event_type == event_type)
     if severity:
         query = query.filter(SecurityEvent.severity == severity)
-    if user_identity:
-        query = query.filter(SecurityEvent.user_identity == user_identity)
+    if resolved_user_id:
+        query = query.filter(SecurityEvent.user_id == resolved_user_id)
 
     events = (
         query.order_by(SecurityEvent.timestamp.desc()).limit(limit).offset(offset).all()
@@ -122,23 +142,14 @@ async def list_security_events(
                 runner_id=event.runner_id,
                 runner_name=event.runner_name,
                 github_runner_id=event.github_runner_id,
-                user_identity=event.user_identity,
+                user_identity=resolve_user_display(event.user_id, db),
                 violation_data=json.loads(event.violation_data),
                 action_taken=event.action_taken,
                 timestamp=event.timestamp,
             )
         )
 
-    # Get total count with same filters
-    total_query = db.query(SecurityEvent)
-    if event_type:
-        total_query = total_query.filter(SecurityEvent.event_type == event_type)
-    if severity:
-        total_query = total_query.filter(SecurityEvent.severity == severity)
-    if user_identity:
-        total_query = total_query.filter(SecurityEvent.user_identity == user_identity)
-
-    total = total_query.count()
+    total = query.count()
 
     return SecurityEventListResponse(events=event_responses, total=total)
 
@@ -489,8 +500,7 @@ async def delete_user(
     label_policy_service.log_security_event(
         event_type="user_deactivated",
         severity="medium",
-        user_identity=admin.identity,
-        oidc_sub=admin.sub,
+        user_id=admin.identity,
         runner_id=None,
         runner_name=None,
         violation_data={
@@ -507,8 +517,7 @@ async def delete_user(
         event_type="user_deactivated",
         runner_id=None,
         runner_name=None,
-        user_identity=admin.identity,
-        oidc_sub=admin.sub,
+        user_id=admin.identity,
         success=True,
         error_message=None,
         event_data=json.dumps(
@@ -684,8 +693,7 @@ async def batch_disable_users(
     label_policy_service.log_security_event(
         event_type="batch_disable_users",
         severity="high",
-        user_identity=admin.identity,
-        oidc_sub=admin.sub,
+        user_id=admin.identity,
         runner_id=None,
         runner_name=None,
         violation_data={
@@ -703,8 +711,7 @@ async def batch_disable_users(
         event_type="batch_disable_users",
         runner_id=None,
         runner_name=None,
-        user_identity=admin.identity,
-        oidc_sub=admin.sub,
+        user_id=admin.identity,
         success=len(failed) == 0,
         error_message=f"{len(failed)} failures" if failed else None,
         event_data=json.dumps(
@@ -819,8 +826,7 @@ async def batch_restore_users(
     label_policy_service.log_security_event(
         event_type="batch_restore_users",
         severity="medium",
-        user_identity=admin.identity,
-        oidc_sub=admin.sub,
+        user_id=admin.identity,
         runner_id=None,
         runner_name=None,
         violation_data={
@@ -880,7 +886,6 @@ async def batch_delete_runners(
     }
     ```
     """
-    from app.models import Runner
     from app.github.client import GitHubClient
 
     label_policy_service = LabelPolicyService(db)
@@ -893,8 +898,22 @@ async def batch_delete_runners(
         # Specific runners
         query = query.filter(Runner.id.in_(request.runner_ids))
     else:
-        # All runners for the specified user
-        query = query.filter(Runner.provisioned_by == request.user_identity)
+        # All runners for the specified user — resolve identity to user_id
+        target_user = (
+            db.query(User)
+            .filter(
+                (User.id == request.user_identity)
+                | (User.email == request.user_identity)
+                | (User.oidc_sub == request.user_identity)
+            )
+            .first()
+        )
+        if target_user is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"User not found: {request.user_identity}",
+            )
+        query = query.filter(Runner.provisioned_by == target_user.id)
 
     runners_to_delete = query.all()
 
@@ -938,8 +957,7 @@ async def batch_delete_runners(
     label_policy_service.log_security_event(
         event_type="batch_delete_runners",
         severity="high",
-        user_identity=admin.identity,
-        oidc_sub=admin.sub,
+        user_id=admin.identity,
         runner_id=None,
         runner_name=None,
         violation_data={
@@ -960,8 +978,7 @@ async def batch_delete_runners(
         event_type="batch_delete_runners",
         runner_id=None,
         runner_name=None,
-        user_identity=admin.identity,
-        oidc_sub=admin.sub,
+        user_id=admin.identity,
         success=len(failed) == 0,
         error_message=f"{len(failed)} failures" if failed else None,
         event_data=json.dumps(
@@ -1082,8 +1099,7 @@ async def batch_deactivate_teams(
     label_policy_service.log_security_event(
         event_type="batch_deactivate_teams",
         severity="high",
-        user_identity=admin.identity,
-        oidc_sub=admin.sub,
+        user_id=admin.identity,
         runner_id=None,
         runner_name=None,
         violation_data={
@@ -1100,8 +1116,7 @@ async def batch_deactivate_teams(
         event_type="batch_deactivate_teams",
         runner_id=None,
         runner_name=None,
-        user_identity=admin.identity,
-        oidc_sub=admin.sub,
+        user_id=admin.identity,
         success=len(failed) == 0,
         error_message=f"{len(failed)} failures" if failed else None,
         event_data=json.dumps(
@@ -1197,8 +1212,7 @@ async def batch_reactivate_teams(
     label_policy_service.log_security_event(
         event_type="batch_reactivate_teams",
         severity="medium",
-        user_identity=admin.identity,
-        oidc_sub=admin.sub,
+        user_id=admin.identity,
         runner_id=None,
         runner_name=None,
         violation_data={

--- a/app/api/v1/audit.py
+++ b/app/api/v1/audit.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from app.auth.dependencies import AuthenticatedUser, get_current_user
 from app.auth.token_types import TokenType
 from app.database import get_db
-from app.models import AuditLog, Team, UserTeamMembership
+from app.models import AuditLog, Team, User, UserTeamMembership, resolve_user_display
 from app.schemas import AuditLogListResponse, AuditLogResponse
 
 router = APIRouter(prefix="/audit-logs", tags=["Audit"])
@@ -114,8 +114,21 @@ async def list_audit_logs(
                 )
             query = query.filter(AuditLog.team_id == team_obj.id)
         elif user_identity:
-            # Admins can filter by user
-            query = query.filter(AuditLog.user_identity == user_identity)
+            # Admins can filter by user: resolve the supplied value to a user_id UUID
+            resolved_user = (
+                db.query(User)
+                .filter(
+                    (User.id == user_identity)
+                    | (User.email == user_identity)
+                    | (User.oidc_sub == user_identity)
+                )
+                .first()
+            )
+            if resolved_user:
+                query = query.filter(AuditLog.user_id == resolved_user.id)
+            else:
+                # No matching user — return empty rather than silently ignoring
+                return AuditLogListResponse(logs=[], total=0)
         # else: admin without filters — no restriction (all logs)
 
     # Apply event_type filter
@@ -150,8 +163,7 @@ async def list_audit_logs(
                 runner_name=log.runner_name,
                 team_id=log.team_id,
                 team_name=(team_name_map.get(log.team_id) if log.team_id else None),
-                user_identity=log.user_identity,
-                oidc_sub=log.oidc_sub,
+                user_identity=resolve_user_display(log.user_id, db),
                 request_ip=log.request_ip,
                 user_agent=log.user_agent,
                 event_data=event_data,

--- a/app/api/v1/runners.py
+++ b/app/api/v1/runners.py
@@ -21,6 +21,7 @@ from app.schemas import (
     RunnerListResponse,
     RunnerStatus,
 )
+from app.models import resolve_user_display
 from app.services.label_policy_service import LabelPolicyViolation
 from app.services.runner_service import RunnerService
 
@@ -151,7 +152,7 @@ async def list_runners(
                 runner_group_id=runner.runner_group_id,
                 labels=json.loads(runner.labels),
                 ephemeral=runner.ephemeral,
-                provisioned_by=runner.provisioned_by,
+                provisioned_by=resolve_user_display(runner.provisioned_by, db),
                 created_at=runner.created_at,
                 updated_at=runner.updated_at,
                 registered_at=runner.registered_at,
@@ -196,7 +197,7 @@ async def get_runner(
         runner_group_id=runner.runner_group_id,
         labels=json.loads(runner.labels) if runner.labels else [],
         ephemeral=runner.ephemeral,
-        provisioned_by=runner.provisioned_by,
+        provisioned_by=resolve_user_display(runner.provisioned_by, db),
         created_at=runner.created_at,
         updated_at=runner.updated_at,
         registered_at=runner.registered_at,
@@ -241,7 +242,7 @@ async def refresh_runner_status(
         runner_group_id=runner.runner_group_id,
         labels=json.loads(runner.labels),
         ephemeral=runner.ephemeral,
-        provisioned_by=runner.provisioned_by,
+        provisioned_by=resolve_user_display(runner.provisioned_by, db),
         created_at=runner.created_at,
         updated_at=runner.updated_at,
         registered_at=runner.registered_at,

--- a/app/api/v1/teams.py
+++ b/app/api/v1/teams.py
@@ -9,7 +9,15 @@ from sqlalchemy.orm import Session
 
 from app.auth.dependencies import AuthenticatedUser, get_current_user
 from app.database import get_db
-from app.models import AuditLog, Runner, SecurityEvent, Team, User, UserTeamMembership
+from app.models import (
+    AuditLog,
+    Runner,
+    SecurityEvent,
+    Team,
+    User,
+    UserTeamMembership,
+    resolve_user_display,
+)
 from app.schemas import (
     AddTeamMemberRequest,
     SecurityEventResponse,
@@ -542,6 +550,7 @@ async def get_team_members(
             TeamMemberResponse(
                 user_id=u.id,
                 email=u.email,
+                oidc_sub=u.oidc_sub,
                 display_name=u.display_name,
                 joined_at=u.created_at,
                 added_by="system",
@@ -591,6 +600,7 @@ async def get_team_members(
             TeamMemberResponse(
                 user_id=member.id,
                 email=member.email,
+                oidc_sub=member.oidc_sub,
                 display_name=member.display_name,
                 joined_at=membership.joined_at if membership else member.created_at,
                 added_by=membership.added_by if membership else None,
@@ -654,6 +664,7 @@ async def add_team_member(
         return TeamMemberResponse(
             user_id=membership.user_id,
             email=user_obj.email if user_obj else None,
+            oidc_sub=user_obj.oidc_sub if user_obj else None,
             display_name=user_obj.display_name if user_obj else None,
             joined_at=membership.joined_at,
             added_by=membership.added_by,
@@ -874,8 +885,7 @@ async def get_team_audit_logs(
                 runner_name=log.runner_name,
                 team_id=team.id,
                 team_name=team.name,
-                user_identity=log.user_identity,
-                oidc_sub=log.oidc_sub,
+                user_identity=resolve_user_display(log.user_id, db),
                 request_ip=log.request_ip,
                 user_agent=log.user_agent,
                 event_data=event_data,
@@ -966,7 +976,7 @@ async def get_team_security_events(
                 github_runner_id=ev.github_runner_id,
                 team_id=team.id,
                 team_name=team.name,
-                user_identity=ev.user_identity,
+                user_identity=resolve_user_display(ev.user_id, db),
                 violation_data=violation_data,
                 action_taken=ev.action_taken,
                 timestamp=ev.timestamp,

--- a/app/api/v1/webhooks.py
+++ b/app/api/v1/webhooks.py
@@ -312,7 +312,7 @@ async def handle_workflow_job(
     label_policy_service.log_security_event(
         event_type="label_policy_violation_workflow",
         severity="high",
-        user_identity=runner.provisioned_by,
+        user_id=runner.provisioned_by,
         runner_id=str(runner.id),
         runner_name=runner_name,
         github_runner_id=runner_id,

--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -120,7 +120,6 @@ def _find_team_by_name(db: Session, team_name: str) -> Optional["Team"]:
 async def _get_authenticated_user(
     payload: dict,
     db: Session,
-    validator: OIDCValidator,
 ) -> AuthenticatedUser:
     """Resolve a verified JWT payload into an AuthenticatedUser.
 
@@ -130,7 +129,6 @@ async def _get_authenticated_user(
     Args:
         payload: Decoded, verified JWT claims.
         db: Database session.
-        validator: OIDCValidator instance (used for identity extraction).
 
     Returns:
         AuthenticatedUser object with database-backed authorization.
@@ -230,13 +228,11 @@ async def _get_authenticated_user(
         )
 
     # --- Individual path ---
-    identity = validator.get_user_identity(payload)
     db_user = _find_user_by_claims(db, payload)
 
     if db_user is None:
         logger.warning(
             "user_not_authorized",
-            identity=identity,
             email=payload.get("email"),
             sub=payload.get("sub"),
         )
@@ -248,7 +244,6 @@ async def _get_authenticated_user(
     if not db_user.is_active:
         logger.warning(
             "user_deactivated",
-            identity=identity,
             user_id=db_user.id,
         )
         raise HTTPException(
@@ -261,7 +256,7 @@ async def _get_authenticated_user(
     db.commit()
 
     return AuthenticatedUser(
-        identity=identity,
+        identity=db_user.id,
         claims=payload,
         token_type=token_type,
         db_user=db_user,
@@ -312,7 +307,7 @@ async def get_current_user(
     token = credentials.credentials
     validator = OIDCValidator(settings)
     payload = await validator.validate_token(token)
-    return await _get_authenticated_user(payload, db, validator)
+    return await _get_authenticated_user(payload, db)
 
 
 async def get_current_user_optional(

--- a/app/auth/oidc.py
+++ b/app/auth/oidc.py
@@ -156,21 +156,3 @@ class OIDCValidator:
                 detail=f"Authentication failed: {str(e)}",
                 headers={"WWW-Authenticate": "Bearer"},
             )
-
-    def get_user_identity(self, payload: dict) -> str:
-        """
-        Extract user identity from token payload.
-
-        Args:
-            payload: Token claims
-
-        Returns:
-            User identity string (email, sub, or preferred_username)
-        """
-        # Try common identity claims in order of preference
-        for claim in ["email", "preferred_username", "sub"]:
-            if claim in payload:
-                return payload[claim]
-
-        # Fallback to sub claim
-        return payload.get("sub", "unknown")

--- a/app/cli.py
+++ b/app/cli.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from app.config import get_settings
 from app.database import SessionLocal, init_db
 from app.github.client import GitHubClient
-from app.models import AuditLog, Runner, User
+from app.models import AuditLog, Runner, User, resolve_user_display
 from app.services.user_service import UserService
 
 
@@ -115,7 +115,19 @@ def list_runners_cmd(status: str, user: str):
         if status:
             query = query.filter(Runner.status == status)
         if user:
-            query = query.filter(Runner.provisioned_by == user)
+            # Accept user_id UUID, email, or oidc_sub
+            target_user = (
+                db.query(User)
+                .filter(
+                    (User.id == user) | (User.email == user) | (User.oidc_sub == user)
+                )
+                .first()
+            )
+            if target_user:
+                query = query.filter(Runner.provisioned_by == target_user.id)
+            else:
+                click.echo(f"No user found matching: {user}")
+                return
 
         runners = query.order_by(Runner.created_at.desc()).all()
 
@@ -134,7 +146,9 @@ def list_runners_cmd(status: str, user: str):
             click.echo(f"GitHub ID:      {runner.github_runner_id or 'N/A'}")
             click.echo(f"Labels:         {labels_str}")
             click.echo(f"Ephemeral:      {runner.ephemeral}")
-            click.echo(f"Provisioned by: {runner.provisioned_by}")
+            click.echo(
+                f"Provisioned by: {resolve_user_display(runner.provisioned_by, db)}"
+            )
             click.echo(f"Created:        {runner.created_at}")
 
             if runner.registered_at:
@@ -169,7 +183,19 @@ def export_audit_log(since: str, event_type: str, user: str, limit: int, output:
         if event_type:
             query = query.filter(AuditLog.event_type == event_type)
         if user:
-            query = query.filter(AuditLog.user_identity == user)
+            # Accept user_id UUID, email, or oidc_sub
+            target_user = (
+                db.query(User)
+                .filter(
+                    (User.id == user) | (User.email == user) | (User.oidc_sub == user)
+                )
+                .first()
+            )
+            if target_user:
+                query = query.filter(AuditLog.user_id == target_user.id)
+            else:
+                click.echo(f"No user found matching: {user}")
+                return
 
         events = query.order_by(AuditLog.timestamp.desc()).limit(limit).all()
 
@@ -186,7 +212,7 @@ def export_audit_log(since: str, event_type: str, user: str, limit: int, output:
                     "timestamp": event.timestamp.isoformat(),
                     "event_type": event.event_type,
                     "runner_name": event.runner_name,
-                    "user_identity": event.user_identity,
+                    "user_identity": resolve_user_display(event.user_id, db),
                     "success": event.success,
                     "error_message": event.error_message,
                     "event_data": json.loads(event.event_data)

--- a/app/models.py
+++ b/app/models.py
@@ -44,8 +44,9 @@ class Runner(Base):
     disable_update = Column(Boolean, default=False, nullable=False)
 
     # Ownership and authentication
-    provisioned_by = Column(String, nullable=False, index=True)  # OIDC identity
-    oidc_sub = Column(String, nullable=True)  # OIDC subject claim
+    provisioned_by = Column(
+        String, nullable=False, index=True
+    )  # User.id UUID or m2m:<team>
 
     # Team association (nullable for backward compatibility)
     team_id = Column(String, ForeignKey("teams.id"), nullable=True, index=True)
@@ -88,15 +89,11 @@ class AuditLog(Base):
     runner_id = Column(String, nullable=True, index=True)
     runner_name = Column(String, nullable=True, index=True)
 
-    # Team association (nullable for backward compatibility)
+    # Team association
     team_id = Column(String, ForeignKey("teams.id"), nullable=True, index=True)
 
-    # User information
-    user_identity = Column(String, nullable=False, index=True)
-    oidc_sub = Column(String, nullable=True)
-
-    # Team association (nullable for backward compatibility)
-    team_id = Column(String, ForeignKey("teams.id"), nullable=True, index=True)
+    # User information — stores User.id UUID, or m2m:<team> for machine tokens
+    user_id = Column(String, nullable=False, index=True)
 
     # Request information
     request_ip = Column(String, nullable=True)
@@ -194,15 +191,11 @@ class SecurityEvent(Base):
     runner_name = Column(String, nullable=True)
     github_runner_id = Column(Integer, nullable=True)
 
-    # Team association (nullable for backward compatibility)
+    # Team association
     team_id = Column(String, ForeignKey("teams.id"), nullable=True, index=True)
 
-    # User information
-    user_identity = Column(String, nullable=False, index=True)
-    oidc_sub = Column(String, nullable=True)
-
-    # Team association (nullable for backward compatibility)
-    team_id = Column(String, ForeignKey("teams.id"), nullable=True, index=True)
+    # User information — stores User.id UUID, or m2m:<team> for machine tokens
+    user_id = Column(String, nullable=False, index=True)
 
     # Violation details
     violation_data = Column(Text, nullable=False)  # JSON with violation specifics
@@ -213,7 +206,7 @@ class SecurityEvent(Base):
 
     __table_args__ = (
         Index("ix_security_events_type_severity", "event_type", "severity"),
-        Index("ix_security_events_user_timestamp", "user_identity", "timestamp"),
+        Index("ix_security_events_user_timestamp", "user_id", "timestamp"),
     )
 
 
@@ -357,3 +350,25 @@ class UserTeamMembership(Base):
         Index("ix_user_team_team", "team_id"),
         Index("ix_user_team_unique", "user_id", "team_id", unique=True),
     )
+
+
+def resolve_user_display(user_id: str, db) -> str:
+    """Resolve a stored user_id to a human-readable display string.
+
+    For individual users, looks up the User row and returns the first
+    available of: display_name, email, oidc_sub, or the raw user_id.
+    For M2M tokens (stored as ``m2m:<team>``), returns the value as-is.
+
+    Args:
+        user_id: Value stored in provisioned_by / AuditLog.user_id / SecurityEvent.user_id.
+        db: SQLAlchemy session.
+
+    Returns:
+        Human-readable display string.
+    """
+    if user_id.startswith("m2m:"):
+        return user_id
+    user = db.query(User).filter(User.id == user_id).first()
+    if user is None:
+        return user_id
+    return user.display_name or user.email or user.oidc_sub or user_id

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -82,7 +82,9 @@ class SecurityEventResponse(BaseModel):
     github_runner_id: Optional[int]
     team_id: Optional[str] = None
     team_name: Optional[str] = None
-    user_identity: str
+    user_identity: (
+        str  # Resolved display string (display_name / email / oidc_sub / user_id)
+    )
     violation_data: dict
     action_taken: Optional[str]
     timestamp: datetime
@@ -305,16 +307,15 @@ class AuditLogResponse(BaseModel):
     runner_name: Optional[str]
     team_id: Optional[str] = None
     team_name: Optional[str] = None
-    user_identity: str
-    oidc_sub: Optional[str]
+    user_identity: (
+        str  # Resolved display string (display_name / email / oidc_sub / user_id)
+    )
     request_ip: Optional[str]
     user_agent: Optional[str]
     event_data: Optional[dict]
     success: bool
     error_message: Optional[str]
     timestamp: datetime
-    team_id: Optional[str] = None
-    team_name: Optional[str] = None
 
 
 class AuditLogListResponse(BaseModel):
@@ -559,6 +560,7 @@ class TeamMemberResponse(BaseModel):
 
     user_id: str
     email: Optional[str]
+    oidc_sub: Optional[str]
     display_name: Optional[str]
     joined_at: datetime
     added_by: Optional[str]

--- a/app/services/label_policy_service.py
+++ b/app/services/label_policy_service.py
@@ -48,12 +48,11 @@ class LabelPolicyService:
         self,
         event_type: str,
         severity: str,
-        user_identity: str,
+        user_id: str,
         runner_id: Optional[str],
         runner_name: Optional[str],
         violation_data: dict,
         action_taken: Optional[str] = None,
-        oidc_sub: Optional[str] = None,
         github_runner_id: Optional[int] = None,
         team_id: Optional[str] = None,
     ) -> SecurityEvent:
@@ -63,12 +62,11 @@ class LabelPolicyService:
         Args:
             event_type: Type of security event
             severity: Event severity (low, medium, high, critical)
-            user_identity: User who triggered the event
+            user_id: User.id UUID (or m2m:<team> for machine tokens)
             runner_id: Internal runner ID
             runner_name: Runner name
             violation_data: Details of the violation
             action_taken: Action taken in response
-            oidc_sub: OIDC subject claim
             github_runner_id: GitHub runner ID
             team_id: Team this event is scoped to (nullable)
 
@@ -89,8 +87,7 @@ class LabelPolicyService:
         event = SecurityEvent(
             event_type=event_type,
             severity=severity,
-            user_identity=user_identity,
-            oidc_sub=oidc_sub,
+            user_id=user_id,
             runner_id=runner_id,
             runner_name=runner_name,
             github_runner_id=github_runner_id,

--- a/app/services/runner_service.py
+++ b/app/services/runner_service.py
@@ -138,8 +138,7 @@ class RunnerService:
             label_policy_service.log_security_event(
                 event_type="label_policy_violation",
                 severity="medium",
-                user_identity=user.identity,
-                oidc_sub=user.sub,
+                user_id=user.identity,
                 runner_id=None,
                 runner_name=runner_name,
                 team_id=team_id,
@@ -178,8 +177,7 @@ class RunnerService:
             label_policy_service.log_security_event(
                 event_type="quota_exceeded",
                 severity="low",
-                user_identity=user.identity,
-                oidc_sub=user.sub,
+                user_id=user.identity,
                 runner_id=None,
                 runner_name=runner_name,
                 team_id=team_id,
@@ -260,7 +258,6 @@ class RunnerService:
             ephemeral=True,  # JIT enforces ephemeral
             disable_update=False,
             provisioned_by=user.identity,
-            oidc_sub=user.sub,
             team_id=team_id,
             team_name=team_name,
             status="pending",
@@ -321,16 +318,12 @@ class RunnerService:
         Returns:
             Runner if found and authorized, None otherwise
         """
-        from sqlalchemy import or_
 
         query = self.db.query(Runner).filter(Runner.id == runner_id)
 
         # If not admin, enforce ownership
         if not user.is_admin:
-            ownership_conditions = [Runner.provisioned_by == user.identity]
-            if user.sub:
-                ownership_conditions.append(Runner.oidc_sub == user.sub)
-            query = query.filter(or_(*ownership_conditions))
+            query = query.filter(Runner.provisioned_by == user.identity)
 
         return query.first()
 
@@ -352,7 +345,6 @@ class RunnerService:
         Returns:
             Runner if found and authorized, None otherwise
         """
-        from sqlalchemy import or_
 
         query = self.db.query(Runner).filter(
             Runner.runner_name == runner_name,
@@ -361,10 +353,7 @@ class RunnerService:
 
         # If not admin, enforce ownership
         if not user.is_admin:
-            ownership_conditions = [Runner.provisioned_by == user.identity]
-            if user.sub:
-                ownership_conditions.append(Runner.oidc_sub == user.sub)
-            query = query.filter(or_(*ownership_conditions))
+            query = query.filter(Runner.provisioned_by == user.identity)
 
         return query.order_by(Runner.created_at.desc()).first()
 
@@ -412,12 +401,9 @@ class RunnerService:
                 .filter(UserTeamMembership.user_id == user.user_id)
                 .scalar_subquery()
             )
-            own_conditions = [Runner.provisioned_by == user.identity]
-            if user.sub:
-                own_conditions.append(Runner.oidc_sub == user.sub)
             query = query.filter(
                 or_(
-                    or_(*own_conditions),
+                    Runner.provisioned_by == user.identity,
                     Runner.team_id.in_(memberships),
                 )
             )
@@ -572,8 +558,7 @@ class RunnerService:
             runner_id=runner_id,
             runner_name=runner_name,
             team_id=resolved_team_id,
-            user_identity=user.identity,
-            oidc_sub=user.sub,
+            user_id=user.identity,
             success=success,
             error_message=error_message,
             event_data=json.dumps(event_data) if event_data else None,

--- a/app/services/sync_service.py
+++ b/app/services/sync_service.py
@@ -370,7 +370,7 @@ class SyncService:
             self.label_policy_service.log_security_event(
                 event_type="label_drift_detected",
                 severity="high",
-                user_identity=runner.provisioned_by,
+                user_id=runner.provisioned_by,
                 runner_id=str(runner.id),
                 runner_name=runner.runner_name,
                 github_runner_id=github_runner.id,
@@ -414,7 +414,7 @@ class SyncService:
         self.label_policy_service.log_security_event(
             event_type="label_drift_detected",
             severity="high",
-            user_identity=runner.provisioned_by,
+            user_id=runner.provisioned_by,
             runner_id=str(runner.id),
             runner_name=runner.runner_name,
             github_runner_id=github_runner.id,

--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -181,7 +181,7 @@ Two authentication paths are supported, distinguished by the `gty` claim in the 
 **Runner:**
 - Identity: `id`, `runner_name`, `github_runner_id`
 - Configuration: `labels`, `ephemeral` (always true for JIT), `runner_group_id`, `disable_update`
-- Ownership: `provisioned_by`, `oidc_sub`
+- Ownership: `provisioned_by` (stores `User.id` UUID, or `m2m:<team>` for machine tokens)
 - Team: `team_id`, `team_name` (denormalized)
 - State: `status` (pending/active/offline/deleted)
 - URL: `github_url`
@@ -189,7 +189,7 @@ Two authentication paths are supported, distinguished by the `gty` claim in the 
 
 **AuditLog:**
 - Event: `event_type`, `runner_id`, `runner_name`, `team_id`
-- User: `user_identity`, `oidc_sub`
+- User: `user_id` (stores `User.id` UUID; resolved to display string in API responses)
 - Context: `request_ip`, `user_agent`
 - Result: `success`, `error_message`
 - Data: `event_data` (JSON)

--- a/docs/design/team_based_authorization.md
+++ b/docs/design/team_based_authorization.md
@@ -62,8 +62,7 @@ erDiagram
         string   runner_name
         int      github_runner_id
         text     labels               "JSON array – provisioned label set"
-        string   provisioned_by       "OIDC identity"
-        string   oidc_sub
+        string   provisioned_by       "User.id UUID or m2m:<team>"
         string   team_id FK
         string   team_name            "Denormalized"
         string   status               "pending | active | offline | deleted"

--- a/docs/oidc_setup.md
+++ b/docs/oidc_setup.md
@@ -571,7 +571,7 @@ The Runner Token Service uses an explicit allowlist approach: users must exist i
 
 | Field | Description |
 |-------|-------------|
-| `email` / `oidc_sub` | User identity (matched from OIDC token claims) |
+| `email` / `oidc_sub` | User identity fields (at least one required; matched from OIDC token `email` / `sub` claims) |
 | `is_admin` | Can manage users and access admin endpoints |
 | `is_active` | Whether the user can access the API (soft delete) |
 | `can_use_jit` | Can use the `/jit` endpoint |

--- a/frontend/src/components/TopNav.tsx
+++ b/frontend/src/components/TopNav.tsx
@@ -13,7 +13,7 @@ export default function TopNav() {
     auth.signoutRedirect()
   }
 
-  const userDisplayName = user?.display_name || user?.email || auth.user?.profile?.email || auth.user?.profile?.name || 'User'
+  const userDisplayName = user?.display_name || user?.email || user?.oidc_sub || auth.user?.profile?.email || auth.user?.profile?.name || 'User'
 
   return (
     <header className="h-16 bg-gh-gray-800 text-white flex items-center justify-between px-4 md:px-6 sticky top-0 z-20">

--- a/frontend/src/hooks/useAdmin.ts
+++ b/frontend/src/hooks/useAdmin.ts
@@ -18,6 +18,7 @@ export interface UserCreate {
   display_name?: string
   is_admin?: boolean
   can_use_jit?: boolean
+  team_ids?: string[]
 }
 
 export interface UserUpdate {

--- a/frontend/src/hooks/useTeams.ts
+++ b/frontend/src/hooks/useTeams.ts
@@ -40,7 +40,8 @@ export interface TeamUpdate {
 
 export interface TeamMember {
   user_id: string
-  email: string
+  email: string | null
+  oidc_sub: string | null
   display_name: string | null
   joined_at: string
 }

--- a/frontend/src/pages/admin/TeamMembers.tsx
+++ b/frontend/src/pages/admin/TeamMembers.tsx
@@ -27,6 +27,9 @@ export default function TeamMembers({ teamId, teamName, onClose }: TeamMembersPr
   const [showAddModal, setShowAddModal] = useState(false)
   const [selectedUserId, setSelectedUserId] = useState('')
 
+  const getMemberLabel = (member: { display_name: string | null; email: string | null; oidc_sub: string | null; user_id: string }): string =>
+    member.display_name ?? member.email ?? member.oidc_sub ?? member.user_id
+
   const handleAddMember = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
@@ -42,10 +45,10 @@ export default function TeamMembers({ teamId, teamName, onClose }: TeamMembersPr
     }
   }
 
-  const handleRemoveMember = async (userId: string, email: string) => {
+  const handleRemoveMember = async (userId: string, label: string) => {
     const confirmMsg = isAdminTeam
-      ? `Remove admin privileges from ${email}?`
-      : `Remove ${email} from ${teamName}?`
+      ? `Remove admin privileges from ${label}?`
+      : `Remove ${label} from ${teamName}?`
     if (!confirm(confirmMsg)) {
       return
     }
@@ -130,10 +133,10 @@ export default function TeamMembers({ teamId, teamName, onClose }: TeamMembersPr
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div>
                         <div className="text-sm font-medium text-gray-900">
-                          {member.display_name || member.email}
+                          {member.display_name ?? member.email ?? member.oidc_sub ?? member.user_id}
                         </div>
                         {member.display_name && (
-                          <div className="text-sm text-gray-500">{member.email}</div>
+                          <div className="text-sm text-gray-500">{member.email ?? member.oidc_sub}</div>
                         )}
                       </div>
                     </td>
@@ -145,7 +148,7 @@ export default function TeamMembers({ teamId, teamName, onClose }: TeamMembersPr
                         menuItems={[
                           {
                             label: 'Remove',
-                            onClick: () => handleRemoveMember(member.user_id, member.email),
+                            onClick: () => handleRemoveMember(member.user_id, getMemberLabel(member)),
                             disabled: removeMember.isPending,
                             variant: 'danger',
                           },
@@ -217,7 +220,7 @@ export default function TeamMembers({ teamId, teamName, onClose }: TeamMembersPr
                       .filter(u => u.is_active && !membersData?.members.some(m => m.user_id === u.id))
                       .map(u => (
                         <option key={u.id} value={u.id}>
-                          {u.email}{u.display_name ? ` (${u.display_name})` : ''}
+                          {u.email ?? u.oidc_sub ?? u.id}{u.display_name ? ` (${u.display_name})` : ''}
                         </option>
                       ))
                     }

--- a/frontend/src/pages/admin/UserManagement.tsx
+++ b/frontend/src/pages/admin/UserManagement.tsx
@@ -9,6 +9,7 @@ export default function UserManagement() {
   const [showAddForm, setShowAddForm] = useState(false)
   const [newUser, setNewUser] = useState({
     email: '',
+    oidc_sub: '',
     display_name: '',
     is_admin: false,
     team_ids: [] as string[],
@@ -126,11 +127,19 @@ export default function UserManagement() {
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault()
+    if (!newUser.email.trim() && !newUser.oidc_sub.trim()) return
     try {
-      await createUser.mutateAsync(newUser)
+      await createUser.mutateAsync({
+        email: newUser.email.trim() || undefined,
+        oidc_sub: newUser.oidc_sub.trim() || undefined,
+        display_name: newUser.display_name.trim() || undefined,
+        is_admin: newUser.is_admin,
+        team_ids: newUser.team_ids,
+      })
       setShowAddForm(false)
       setNewUser({
         email: '',
+        oidc_sub: '',
         display_name: '',
         is_admin: false,
         team_ids: [],
@@ -266,10 +275,11 @@ export default function UserManagement() {
           <form onSubmit={handleCreate} className="space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700">Email</label>
+                <label className="block text-sm font-medium text-gray-700">
+                  Email <span className="text-xs text-gray-400">(or OIDC Subject below)</span>
+                </label>
                 <input
                   type="email"
-                  required
                   value={newUser.email}
                   onChange={(e) => setNewUser({ ...newUser, email: e.target.value })}
                   className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-gh-blue focus:border-gh-blue"
@@ -277,10 +287,26 @@ export default function UserManagement() {
                 />
               </div>
               <div>
+                <label className="block text-sm font-medium text-gray-700">
+                  OIDC Subject <span className="text-xs text-gray-400">(or Email above)</span>
+                </label>
+                <input
+                  type="text"
+                  value={newUser.oidc_sub}
+                  onChange={(e) => setNewUser({ ...newUser, oidc_sub: e.target.value })}
+                  className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-gh-blue focus:border-gh-blue"
+                  placeholder="auth0|abc123"
+                />
+              </div>
+            </div>
+            {!newUser.email.trim() && !newUser.oidc_sub.trim() && (
+              <p className="text-sm text-red-600">At least one of Email or OIDC Subject is required.</p>
+            )}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
                 <label className="block text-sm font-medium text-gray-700">Display Name</label>
                 <input
                   type="text"
-                  required
                   value={newUser.display_name}
                   onChange={(e) => setNewUser({ ...newUser, display_name: e.target.value })}
                   className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-gh-blue focus:border-gh-blue"
@@ -389,7 +415,11 @@ export default function UserManagement() {
             <div className="flex justify-end">
               <button
                 type="submit"
-                disabled={createUser.isPending || (!newUser.is_admin && newUser.team_ids.length === 0)}
+                disabled={
+                  createUser.isPending ||
+                  (!newUser.email.trim() && !newUser.oidc_sub.trim()) ||
+                  (!newUser.is_admin && newUser.team_ids.length === 0)
+                }
                 className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-gh-blue hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {createUser.isPending ? 'Creating...' : 'Create User'}

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -74,7 +74,7 @@ class TestSecurityEventsEndpoints:
         event = SecurityEvent(
             event_type="label_policy_violation",
             severity="medium",
-            user_identity="violator@example.com",
+            user_id="m2m:test-team",
             violation_data=json.dumps({"reason": "test violation"}),
         )
         test_db.add(event)
@@ -95,7 +95,7 @@ class TestSecurityEventsEndpoints:
             event = SecurityEvent(
                 event_type="test_event",
                 severity=severity,
-                user_identity="test@example.com",
+                user_id="m2m:test-team",
                 violation_data=json.dumps({}),
             )
             test_db.add(event)

--- a/tests/test_batch_admin.py
+++ b/tests/test_batch_admin.py
@@ -2,7 +2,7 @@
 
 from sqlalchemy.orm import Session
 
-from app.models import Runner, SecurityEvent
+from app.models import Runner, SecurityEvent, User
 from app.services.team_service import TeamService
 from app.services.user_service import UserService
 
@@ -355,13 +355,21 @@ class TestBatchDeleteRunners:
         self, client, admin_auth_override, test_db: Session
     ):
         """Test deleting all runners for a specific user."""
+        # Create users and use their UUIDs as provisioned_by
+        user1 = User(email="user1@example.com", is_active=True)
+        user2 = User(email="user2@example.com", is_active=True)
+        test_db.add_all([user1, user2])
+        test_db.commit()
+        test_db.refresh(user1)
+        test_db.refresh(user2)
+
         # Create runners for different users
         runner1 = Runner(
             runner_name="user1-runner-1",
             runner_group_id=1,
             labels="[]",
             ephemeral=True,
-            provisioned_by="user1@example.com",
+            provisioned_by=user1.id,
             status="active",
             github_url="https://github.com/test-org",
         )
@@ -370,7 +378,7 @@ class TestBatchDeleteRunners:
             runner_group_id=1,
             labels="[]",
             ephemeral=True,
-            provisioned_by="user1@example.com",
+            provisioned_by=user1.id,
             status="active",
             github_url="https://github.com/test-org",
         )
@@ -379,7 +387,7 @@ class TestBatchDeleteRunners:
             runner_group_id=1,
             labels="[]",
             ephemeral=True,
-            provisioned_by="user2@example.com",
+            provisioned_by=user2.id,
             status="active",
             github_url="https://github.com/test-org",
         )
@@ -456,12 +464,17 @@ class TestBatchDeleteRunners:
     def test_batch_delete_empty_result(
         self, client, admin_auth_override, test_db: Session
     ):
-        """Test batch delete with no matching runners."""
+        """Test batch delete for a user with no runners returns 200 with affected_count=0."""
+        # Create a user with no runners
+        user = User(email="no-runners@example.com", is_active=True)
+        test_db.add(user)
+        test_db.commit()
+
         response = client.post(
             "/api/v1/admin/batch/delete-runners",
             json={
                 "comment": "No runners to delete - testing empty case",
-                "user_identity": "nonexistent@example.com",
+                "user_identity": "no-runners@example.com",
             },
         )
 
@@ -469,6 +482,18 @@ class TestBatchDeleteRunners:
         data = response.json()
         assert data["success"] is True
         assert data["affected_count"] == 0
+
+    def test_batch_delete_user_not_found(self, client, admin_auth_override):
+        """Test batch delete for a nonexistent user returns 404."""
+        response = client.post(
+            "/api/v1/admin/batch/delete-runners",
+            json={
+                "comment": "No runners to delete - testing not found case",
+                "user_identity": "nonexistent@example.com",
+            },
+        )
+
+        assert response.status_code == 404
 
 
 class TestBatchDeactivateTeams:

--- a/tests/test_rbac_enforcement.py
+++ b/tests/test_rbac_enforcement.py
@@ -124,16 +124,15 @@ class TestRunnerEndpointsRBAC:
         # Create two users
         user_service = UserService(test_db)
         alice_db = user_service.create_user(email="alice@example.com", can_use_jit=True)
-        user_service.create_user(email="bob@example.com", can_use_jit=True)
+        bob_db = user_service.create_user(email="bob@example.com", can_use_jit=True)
 
-        # Create runners for each user
+        # Create runners for each user (provisioned_by stores User.id UUID)
         alice_runner = Runner(
             runner_name="alice-runner",
             runner_group_id=1,
             labels='["linux"]',
             ephemeral=True,
-            provisioned_by="alice@example.com",
-            oidc_sub="auth0|alice",
+            provisioned_by=alice_db.id,
             status="active",
             github_url="https://github.com/test-org",
         )
@@ -142,8 +141,7 @@ class TestRunnerEndpointsRBAC:
             runner_group_id=1,
             labels='["linux"]',
             ephemeral=True,
-            provisioned_by="bob@example.com",
-            oidc_sub="auth0|bob",
+            provisioned_by=bob_db.id,
             status="active",
             github_url="https://github.com/test-org",
         )
@@ -155,9 +153,9 @@ class TestRunnerEndpointsRBAC:
         mock_settings = MagicMock()
         mock_settings.enable_oidc_auth = True
 
-        # Test as Alice
+        # Test as Alice (identity is now db_user.id)
         alice_user = AuthenticatedUser(
-            identity="alice@example.com",
+            identity=alice_db.id,
             claims={"sub": "auth0|alice", "email": "alice@example.com"},
             db_user=alice_db,
         )
@@ -193,16 +191,15 @@ class TestRunnerEndpointsRBAC:
         # Create users
         user_service = UserService(test_db)
         alice_db = user_service.create_user(email="alice2@example.com")
-        user_service.create_user(email="bob2@example.com")
+        bob_db = user_service.create_user(email="bob2@example.com")
 
-        # Create runner for Bob
+        # Create runner for Bob (provisioned_by stores User.id UUID)
         bob_runner = Runner(
             runner_name="bob-private-runner",
             runner_group_id=1,
             labels='["linux"]',
             ephemeral=True,
-            provisioned_by="bob2@example.com",
-            oidc_sub="auth0|bob2",
+            provisioned_by=bob_db.id,
             status="active",
             github_url="https://github.com/test-org",
         )
@@ -213,9 +210,9 @@ class TestRunnerEndpointsRBAC:
         mock_settings = MagicMock()
         mock_settings.enable_oidc_auth = True
 
-        # Alice tries to view Bob's runner
+        # Alice tries to view Bob's runner (identity is now db_user.id)
         alice_user = AuthenticatedUser(
-            identity="alice2@example.com",
+            identity=alice_db.id,
             claims={"sub": "auth0|alice2", "email": "alice2@example.com"},
             db_user=alice_db,
         )
@@ -248,16 +245,15 @@ class TestRunnerEndpointsRBAC:
         # Create users
         user_service = UserService(test_db)
         alice_db = user_service.create_user(email="alice3@example.com")
-        user_service.create_user(email="bob3@example.com")
+        bob_db = user_service.create_user(email="bob3@example.com")
 
-        # Create runner for Bob
+        # Create runner for Bob (provisioned_by stores User.id UUID)
         bob_runner = Runner(
             runner_name="bob-delete-test",
             runner_group_id=1,
             labels='["linux"]',
             ephemeral=True,
-            provisioned_by="bob3@example.com",
-            oidc_sub="auth0|bob3",
+            provisioned_by=bob_db.id,
             status="active",
             github_url="https://github.com/test-org",
         )
@@ -268,9 +264,9 @@ class TestRunnerEndpointsRBAC:
         mock_settings = MagicMock()
         mock_settings.enable_oidc_auth = True
 
-        # Alice tries to delete Bob's runner
+        # Alice tries to delete Bob's runner (identity is now db_user.id)
         alice_user = AuthenticatedUser(
-            identity="alice3@example.com",
+            identity=alice_db.id,
             claims={"sub": "auth0|alice3", "email": "alice3@example.com"},
             db_user=alice_db,
         )

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -277,30 +277,22 @@ class TestDeleteRunner:
         assert response.status_code == 400
         assert "already deleted" in response.json()["detail"].lower()
 
-    def test_delete_runner_by_oidc_sub_when_identity_differs(
+    def test_delete_runner_provisioned_by_different_user_is_forbidden(
         self, client: TestClient, test_db: Session, mock_user
     ):
         """
-        REGRESSION TEST: User should be able to delete runners provisioned by them
-        even when their OIDC token has different claims.
-
-        Scenario: User provisions runner with email-based identity, then tries to
-        delete with M2M token that only has 'sub' claim. The ownership check should
-        match on oidc_sub as well as provisioned_by.
-
-        Fix: get_runner_by_id now checks both provisioned_by == user.identity
-        OR oidc_sub == user.sub for ownership.
+        Ownership check uses provisioned_by (User.id UUID) exclusively.
+        A runner provisioned by a different user_id cannot be deleted by another user.
         """
         from app.auth.dependencies import get_current_user
         from app.main import app
 
-        # Runner was provisioned with email identity
+        # Runner was provisioned by a different user (different UUID)
         runner = Runner(
-            runner_name="sub-match-runner",
+            runner_name="other-user-runner",
             runner_group_id=1,
             labels=json.dumps(["test"]),
-            provisioned_by="different-identity@example.com",  # Different from user.identity
-            oidc_sub=mock_user.sub,  # But same OIDC sub
+            provisioned_by="00000000-0000-0000-0000-000000000099",  # Different UUID
             status="active",
             github_url="https://github.com/test-org",
         )
@@ -309,27 +301,20 @@ class TestDeleteRunner:
         test_db.refresh(runner)
         runner_id = runner.id
 
-        # Override auth to use mock_user (whose sub matches oidc_sub)
+        # Override auth to use mock_user (whose identity is a different UUID)
         async def override_get_current_user():
             return mock_user
 
         app.dependency_overrides[get_current_user] = override_get_current_user
 
         try:
-            with patch("app.services.runner_service.GitHubClient") as MockGitHubClient:
-                mock_github = AsyncMock()
-                mock_github.delete_runner = AsyncMock(return_value=True)
-                MockGitHubClient.return_value = mock_github
+            response = client.delete(f"/api/v1/runners/{runner_id}")
 
-                response = client.delete(f"/api/v1/runners/{runner_id}")
-
-            # Should be able to delete because oidc_sub matches
-            assert response.status_code == 200, (
-                f"Expected 200 OK when deleting runner by OIDC sub match, "
+            # Should be forbidden because provisioned_by does not match user.identity
+            assert response.status_code in (403, 404), (
+                f"Expected 403/404 when deleting runner owned by different user, "
                 f"got {response.status_code}: {response.json()}"
             )
-            data = response.json()
-            assert data["success"] is True
         finally:
             app.dependency_overrides.pop(get_current_user, None)
 

--- a/tests/test_sub_support.py
+++ b/tests/test_sub_support.py
@@ -1,0 +1,588 @@
+"""Tests for OIDC sub claim support — stable User.id-based identity storage.
+
+Covers:
+- resolve_user_display: all priority branches
+  (display_name > email > oidc_sub > id)
+- resolve_user_display: m2m passthrough, unknown UUID fallback
+- Security event response: user_identity is a resolved display string
+- Security event filter: user_identity param resolved by email
+- Audit log response: user_identity is a resolved display string
+- Audit log filter: user_identity resolved by email / sub / UUID
+- Team members response: oidc_sub field present for sub-only users
+- Admin user create API: sub-only user (no email)
+- Runner provisioned_by response: resolved display string
+- Batch delete runners: user lookup by email, sub, and UUID
+"""
+
+import json
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import AuditLog, Runner, SecurityEvent, User, resolve_user_display
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for resolve_user_display
+# ---------------------------------------------------------------------------
+
+
+class TestResolveUserDisplay:
+    """Unit tests for the resolve_user_display helper."""
+
+    def test_display_name_takes_priority(self, test_db: Session):
+        user = User(
+            email="a@example.com",
+            oidc_sub="auth0|aaa",
+            display_name="Alice Smith",
+            is_active=True,
+        )
+        test_db.add(user)
+        test_db.commit()
+        assert resolve_user_display(user.id, test_db) == "Alice Smith"
+
+    def test_email_fallback(self, test_db: Session):
+        user = User(email="b@example.com", oidc_sub="auth0|bbb", is_active=True)
+        test_db.add(user)
+        test_db.commit()
+        assert resolve_user_display(user.id, test_db) == "b@example.com"
+
+    def test_oidc_sub_fallback(self, test_db: Session):
+        user = User(oidc_sub="auth0|ccc", is_active=True)
+        test_db.add(user)
+        test_db.commit()
+        assert resolve_user_display(user.id, test_db) == "auth0|ccc"
+
+    def test_user_id_last_resort(self, test_db: Session):
+        user = User(is_active=True)
+        test_db.add(user)
+        test_db.commit()
+        assert resolve_user_display(user.id, test_db) == user.id
+
+    def test_m2m_string_passthrough(self, test_db: Session):
+        result = resolve_user_display("m2m:platform-team", test_db)
+        assert result == "m2m:platform-team"
+
+    def test_unknown_uuid_returns_as_is(self, test_db: Session):
+        unknown = "00000000-0000-0000-0000-000000000099"
+        assert resolve_user_display(unknown, test_db) == unknown
+
+
+# ---------------------------------------------------------------------------
+# Security events: user_identity in response is resolved display string
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityEventResolution:
+    """Security event responses expose a resolved user_identity string."""
+
+    def test_security_event_user_identity_is_resolved(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,  # noqa: ARG002
+    ):
+        user = User(
+            email="violator@example.com",
+            display_name="Eve Violator",
+            is_active=True,
+        )
+        test_db.add(user)
+        test_db.commit()
+
+        event = SecurityEvent(
+            event_type="label_policy_violation",
+            severity="high",
+            user_id=user.id,
+            violation_data=json.dumps({"reason": "bad label"}),
+        )
+        test_db.add(event)
+        test_db.commit()
+
+        response = client.get("/api/v1/admin/security-events")
+        assert response.status_code == 200
+        events = response.json()["events"]
+        matching = [e for e in events if e["event_type"] == "label_policy_violation"]
+        assert matching, "Expected at least one label_policy_violation event"
+        assert matching[0]["user_identity"] == "Eve Violator"
+
+    def test_security_event_m2m_user_identity_passthrough(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,  # noqa: ARG002
+    ):
+        event = SecurityEvent(
+            event_type="quota_exceeded",
+            severity="medium",
+            user_id="m2m:ci-team",
+            violation_data=json.dumps({}),
+        )
+        test_db.add(event)
+        test_db.commit()
+
+        response = client.get("/api/v1/admin/security-events")
+        assert response.status_code == 200
+        events = response.json()["events"]
+        matching = [e for e in events if e["event_type"] == "quota_exceeded"]
+        assert matching
+        assert matching[0]["user_identity"] == "m2m:ci-team"
+
+    def test_security_event_filter_by_user_email(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,  # noqa: ARG002
+    ):
+        user = User(email="filtered@example.com", is_active=True)
+        other = User(email="other@example.com", is_active=True)
+        test_db.add_all([user, other])
+        test_db.commit()
+
+        test_db.add(
+            SecurityEvent(
+                event_type="label_policy_violation",
+                severity="low",
+                user_id=user.id,
+                violation_data=json.dumps({}),
+            )
+        )
+        test_db.add(
+            SecurityEvent(
+                event_type="label_policy_violation",
+                severity="low",
+                user_id=other.id,
+                violation_data=json.dumps({}),
+            )
+        )
+        test_db.commit()
+
+        response = client.get(
+            "/api/v1/admin/security-events",
+            params={"user_identity": "filtered@example.com"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["events"][0]["user_identity"] == "filtered@example.com"
+
+
+# ---------------------------------------------------------------------------
+# Audit log: user_identity filter resolves by email, sub, and UUID
+# ---------------------------------------------------------------------------
+
+
+class TestAuditLogResolution:
+    """Audit log responses expose resolved user_identity; filter accepts
+    email/sub/UUID."""
+
+    def _make_audit(self, test_db: Session, user_id: str) -> AuditLog:
+        log = AuditLog(
+            event_type="provision_runner",
+            user_id=user_id,
+            success=True,
+        )
+        test_db.add(log)
+        test_db.commit()
+        return log
+
+    def test_audit_log_user_identity_resolved(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,  # noqa: ARG002
+    ):
+        user = User(
+            email="runner-user@example.com",
+            display_name="Runner User",
+            is_active=True,
+        )
+        test_db.add(user)
+        test_db.commit()
+        self._make_audit(test_db, user.id)
+
+        response = client.get("/api/v1/audit-logs")
+        assert response.status_code == 200
+        logs = response.json()["logs"]
+        matching = [
+            entry for entry in logs if entry["event_type"] == "provision_runner"
+        ]
+        assert matching
+        assert matching[0]["user_identity"] == "Runner User"
+
+    def test_audit_log_filter_by_email(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,  # noqa: ARG002
+    ):
+        user = User(email="audit-filter@example.com", is_active=True)
+        other = User(email="noise@example.com", is_active=True)
+        test_db.add_all([user, other])
+        test_db.commit()
+        self._make_audit(test_db, user.id)
+        self._make_audit(test_db, other.id)
+
+        response = client.get(
+            "/api/v1/audit-logs",
+            params={"user_identity": "audit-filter@example.com"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["logs"][0]["user_identity"] == "audit-filter@example.com"
+
+    def test_audit_log_filter_by_oidc_sub(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,  # noqa: ARG002
+    ):
+        user = User(oidc_sub="auth0|auditSub", is_active=True)
+        test_db.add(user)
+        test_db.commit()
+        self._make_audit(test_db, user.id)
+
+        response = client.get(
+            "/api/v1/audit-logs",
+            params={"user_identity": "auth0|auditSub"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["logs"][0]["user_identity"] == "auth0|auditSub"
+
+    def test_audit_log_filter_by_user_id(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,  # noqa: ARG002
+    ):
+        user = User(email="uuid-filter@example.com", is_active=True)
+        test_db.add(user)
+        test_db.commit()
+        self._make_audit(test_db, user.id)
+
+        response = client.get(
+            "/api/v1/audit-logs",
+            params={"user_identity": user.id},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Team members: oidc_sub present in response for sub-only users
+# ---------------------------------------------------------------------------
+
+
+class TestTeamMembersSubOnly:
+    """Team member responses include oidc_sub for sub-only users."""
+
+    def test_sub_only_member_in_team_response(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,  # noqa: ARG002
+    ):
+        from app.models import Team, UserTeamMembership
+
+        team = Team(
+            name="sub-only-team",
+            required_labels=json.dumps([]),
+            optional_label_patterns=json.dumps([]),
+            is_active=True,
+        )
+        test_db.add(team)
+        test_db.commit()
+
+        user = User(oidc_sub="auth0|subOnly", is_active=True)
+        test_db.add(user)
+        test_db.commit()
+
+        test_db.add(UserTeamMembership(user_id=user.id, team_id=team.id))
+        test_db.commit()
+
+        response = client.get(f"/api/v1/admin/teams/{team.id}/members")
+        assert response.status_code == 200
+        members = response.json()["members"]
+        assert len(members) == 1
+        member = members[0]
+        assert member["oidc_sub"] == "auth0|subOnly"
+        assert member["email"] is None
+
+    def test_email_only_member_has_null_oidc_sub(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,  # noqa: ARG002
+    ):
+        from app.models import Team, UserTeamMembership
+
+        team = Team(
+            name="email-only-team",
+            required_labels=json.dumps([]),
+            optional_label_patterns=json.dumps([]),
+            is_active=True,
+        )
+        test_db.add(team)
+        test_db.commit()
+
+        user = User(email="email-only@example.com", is_active=True)
+        test_db.add(user)
+        test_db.commit()
+
+        test_db.add(UserTeamMembership(user_id=user.id, team_id=team.id))
+        test_db.commit()
+
+        response = client.get(f"/api/v1/admin/teams/{team.id}/members")
+        assert response.status_code == 200
+        members = response.json()["members"]
+        assert len(members) == 1
+        member = members[0]
+        assert member["email"] == "email-only@example.com"
+        assert member["oidc_sub"] is None
+
+
+# ---------------------------------------------------------------------------
+# Admin user create API: sub-only user
+# ---------------------------------------------------------------------------
+
+
+class TestSubOnlyUserCreate:
+    """Admin can create users with only oidc_sub (no email)."""
+
+    def test_create_sub_only_admin_user(
+        self,
+        client: TestClient,
+        test_db: Session,  # noqa: ARG002
+        admin_auth_override,  # noqa: ARG002
+    ):
+        # is_admin=True bypasses the team_ids requirement
+        response = client.post(
+            "/api/v1/admin/users",
+            json={"oidc_sub": "auth0|newSubUser", "is_admin": True},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["oidc_sub"] == "auth0|newSubUser"
+        assert data["email"] is None
+
+    def test_create_sub_only_non_admin_user_requires_team(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,  # noqa: ARG002
+    ):
+        """Non-admin sub-only users must be assigned to at least one team."""
+        from app.models import Team
+
+        team = Team(
+            name="sub-user-team",
+            required_labels=json.dumps([]),
+            optional_label_patterns=json.dumps([]),
+            is_active=True,
+        )
+        test_db.add(team)
+        test_db.commit()
+
+        response = client.post(
+            "/api/v1/admin/users",
+            json={"oidc_sub": "auth0|teamSubUser", "team_ids": [team.id]},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["oidc_sub"] == "auth0|teamSubUser"
+        assert data["email"] is None
+
+    def test_create_sub_only_user_can_be_retrieved(
+        self,
+        client: TestClient,
+        test_db: Session,  # noqa: ARG002
+        admin_auth_override,  # noqa: ARG002
+    ):
+        create_resp = client.post(
+            "/api/v1/admin/users",
+            json={"oidc_sub": "auth0|retrieveSub", "is_admin": True},
+        )
+        assert create_resp.status_code == 201
+        user_id = create_resp.json()["id"]
+
+        get_resp = client.get(f"/api/v1/admin/users/{user_id}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["oidc_sub"] == "auth0|retrieveSub"
+
+    def test_create_user_without_email_or_sub_rejected(
+        self,
+        client: TestClient,
+        test_db: Session,  # noqa: ARG002
+        admin_auth_override,  # noqa: ARG002
+    ):
+        response = client.post(
+            "/api/v1/admin/users",
+            json={"display_name": "No Identity", "is_admin": True},
+        )
+        assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Runner provisioned_by response: resolved display string
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerProvisionedByDisplay:
+    """Runner list responses show a resolved string for provisioned_by."""
+
+    def test_runner_provisioned_by_resolved_to_display_name(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,  # noqa: ARG002
+    ):
+        user = User(
+            email="runner-owner@example.com",
+            display_name="Runner Owner",
+            is_active=True,
+        )
+        test_db.add(user)
+        test_db.commit()
+
+        runner = Runner(
+            runner_name="owned-runner",
+            runner_group_id=1,
+            labels=json.dumps(["self-hosted"]),
+            provisioned_by=user.id,
+            status="active",
+            github_url="https://github.com/test-org",
+        )
+        test_db.add(runner)
+        test_db.commit()
+
+        # Admin sees all runners
+        response = client.get("/api/v1/runners")
+        assert response.status_code == 200
+        runners = response.json()["runners"]
+        matching = [r for r in runners if r["runner_name"] == "owned-runner"]
+        assert matching
+        assert matching[0]["provisioned_by"] == "Runner Owner"
+
+    def test_runner_provisioned_by_resolved_to_sub_for_sub_only_user(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,  # noqa: ARG002
+    ):
+        user = User(oidc_sub="auth0|subOwner", is_active=True)
+        test_db.add(user)
+        test_db.commit()
+
+        runner = Runner(
+            runner_name="sub-owned-runner",
+            runner_group_id=1,
+            labels=json.dumps(["self-hosted"]),
+            provisioned_by=user.id,
+            status="active",
+            github_url="https://github.com/test-org",
+        )
+        test_db.add(runner)
+        test_db.commit()
+
+        response = client.get("/api/v1/runners")
+        assert response.status_code == 200
+        runners = response.json()["runners"]
+        matching = [r for r in runners if r["runner_name"] == "sub-owned-runner"]
+        assert matching
+        assert matching[0]["provisioned_by"] == "auth0|subOwner"
+
+    def test_runner_provisioned_by_m2m_passthrough(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,  # noqa: ARG002
+    ):
+        runner = Runner(
+            runner_name="m2m-runner",
+            runner_group_id=1,
+            labels=json.dumps(["self-hosted"]),
+            provisioned_by="m2m:ci-team",
+            status="active",
+            github_url="https://github.com/test-org",
+        )
+        test_db.add(runner)
+        test_db.commit()
+
+        response = client.get("/api/v1/runners")
+        assert response.status_code == 200
+        runners = response.json()["runners"]
+        matching = [r for r in runners if r["runner_name"] == "m2m-runner"]
+        assert matching
+        assert matching[0]["provisioned_by"] == "m2m:ci-team"
+
+
+# ---------------------------------------------------------------------------
+# Batch delete runners: user lookup by email, sub, and UUID
+# ---------------------------------------------------------------------------
+
+
+class TestBatchDeleteUserLookup:
+    """Batch delete runners accepts user lookup by email, sub, or UUID."""
+
+    def _make_runner_for(self, test_db: Session, user: User, name: str) -> Runner:
+        runner = Runner(
+            runner_name=name,
+            runner_group_id=1,
+            labels="[]",
+            provisioned_by=user.id,
+            status="active",
+            github_url="https://github.com/test-org",
+        )
+        test_db.add(runner)
+        test_db.commit()
+        return runner
+
+    def test_batch_delete_by_sub(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,  # noqa: ARG002
+    ):
+        user = User(oidc_sub="auth0|batchSub", is_active=True)
+        test_db.add(user)
+        test_db.commit()
+        runner = self._make_runner_for(test_db, user, "batch-sub-runner")
+
+        response = client.post(
+            "/api/v1/admin/batch/delete-runners",
+            json={
+                "comment": "Termination: sub-only user cleanup",
+                "user_identity": "auth0|batchSub",
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["affected_count"] == 1
+        test_db.refresh(runner)
+        assert runner.status == "deleted"
+
+    def test_batch_delete_by_uuid(
+        self,
+        client: TestClient,
+        test_db: Session,
+        admin_auth_override,  # noqa: ARG002
+    ):
+        user = User(email="uuid-batch@example.com", is_active=True)
+        test_db.add(user)
+        test_db.commit()
+        runner = self._make_runner_for(test_db, user, "batch-uuid-runner")
+
+        response = client.post(
+            "/api/v1/admin/batch/delete-runners",
+            json={
+                "comment": "Termination: uuid-based cleanup",
+                "user_identity": user.id,
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["affected_count"] == 1
+        test_db.refresh(runner)
+        assert runner.status == "deleted"

--- a/tests/test_team_scoped_listing.py
+++ b/tests/test_team_scoped_listing.py
@@ -55,16 +55,16 @@ def _add_to_team(db: Session, user: User, team: Team) -> None:
 def _make_runner(
     db: Session,
     name: str,
-    provisioned_by: str,
+    provisioned_by: "str | User",
     team: Team,
-    oidc_sub: str = "",
 ) -> Runner:
+    # Accept either a User object (use its id) or a plain string
+    pb = provisioned_by.id if isinstance(provisioned_by, User) else provisioned_by
     runner = Runner(
         runner_name=name,
         runner_group_id=1,
         labels=json.dumps(["self-hosted"]),
-        provisioned_by=provisioned_by,
-        oidc_sub=oidc_sub or None,
+        provisioned_by=pb,
         team_id=team.id,
         team_name=team.name,
         github_url="https://github.com/test-org",
@@ -90,7 +90,7 @@ def _individual_user(
     claims: dict | None = None,
 ) -> AuthenticatedUser:
     return AuthenticatedUser(
-        identity=db_user.email,
+        identity=db_user.id,
         claims=claims or {"email": db_user.email, "sub": f"sub|{db_user.id}"},
         token_type=TokenType.INDIVIDUAL,
         db_user=db_user,
@@ -108,7 +108,7 @@ def _m2m_user(team: Team) -> AuthenticatedUser:
 
 def _admin_user(db_user: User) -> AuthenticatedUser:
     u = AuthenticatedUser(
-        identity=db_user.email,
+        identity=db_user.id,
         claims={"email": db_user.email},
         token_type=TokenType.INDIVIDUAL,
         db_user=db_user,
@@ -130,7 +130,7 @@ class TestListRunnersVisibility:
         team = _make_team(test_db, "team-a")
         alice_db = _make_user(test_db, "alice@example.com")
         _add_to_team(test_db, alice_db, team)
-        _make_runner(test_db, "alice-runner", "alice@example.com", team)
+        _make_runner(test_db, "alice-runner", alice_db, team)
         _make_runner(test_db, "other-runner", "bob@example.com", team)
 
         alice = _individual_user(alice_db)
@@ -221,7 +221,7 @@ class TestListRunnersVisibility:
         team = _make_team(test_db, "deleted-team")
         alice_db = _make_user(test_db, "alice4@example.com")
         _add_to_team(test_db, alice_db, team)
-        r = _make_runner(test_db, "dead-runner", "alice4@example.com", team)
+        r = _make_runner(test_db, "dead-runner", alice_db, team)
         r.status = "deleted"
         test_db.commit()
 


### PR DESCRIPTION
## Summary

- **Stable identity storage**: Replace mutable identity strings (email/sub) with the stable `User.id` UUID in `Runner.provisioned_by`, `AuditLog.user_id`, and `SecurityEvent.user_id`. Display values are resolved at read time via `resolve_user_display()` (`display_name → email → oidc_sub → user_id`; m2m strings pass through as-is).
- **oidc_sub surfaced in frontend**: Users identified only by OIDC `sub` claim (no email) are now handled correctly in all UI components — team member list, user create form, runner ownership display, top nav.
- **Sub-only user support**: Admin "Add User" form now accepts `oidc_sub` as an alternative (or sole) identifier; validation requires at least one of email or sub.

## Backend changes

- `models.py`: drop `Runner.oidc_sub`; rename `AuditLog`/`SecurityEvent` `user_identity` → `user_id`, drop `oidc_sub`; add `resolve_user_display()` helper
- `auth/dependencies.py`: set `AuthenticatedUser.identity = db_user.id`; remove `get_user_identity()` call
- `auth/oidc.py`: remove `get_user_identity()` method
- Services: write `user_id` (not identity string) to all audit/ownership fields
- `api/v1/runners`, `audit`, `admin`, `teams`: resolve `user_id` to display string in responses; accept email/sub/UUID in `user_identity` filter params
- `schemas.py`: add `oidc_sub` to `TeamMemberResponse`
- `cli.py`: resolve `user_id` for display; accept email/sub/UUID in `--user` filter

## Frontend changes

- `useTeams.ts`: make `TeamMember.email` nullable, add `oidc_sub` field
- `useAdmin.ts`: add `team_ids` to `UserCreate` interface
- `TeamMembers.tsx`: display `oidc_sub` as fallback; fix remove-member confirm message
- `UserManagement.tsx`: add OIDC Subject input to create form; require email or sub
- `TopNav.tsx`: add `oidc_sub` fallback in display name chain

## Test plan

- [x] All 371 backend tests pass (`pytest tests/ -q`)
- [x] Frontend type check clean (`npm run typecheck`)
- [x] 112 frontend tests pass (`npm run test -- --run`)
- [x] Pre-commit hooks pass (ruff, pytest, eslint, tsc)
- [x] New `tests/test_sub_support.py` adds 24 targeted tests:
  - `resolve_user_display` unit tests (all priority branches, m2m passthrough, unknown UUID)
  - Security event response resolution and email filter
  - Audit log response resolution and email/sub/UUID filter
  - Team members `oidc_sub` field for sub-only users
  - Sub-only user creation via admin API
  - Runner `provisioned_by` display resolution
  - Batch delete runner lookup by sub and UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)